### PR TITLE
feat : 주문 도메인 CRUD 개발 #5

### DIFF
--- a/src/main/java/com/example/whostolemyfood/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/example/whostolemyfood/global/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.example.whostolemyfood.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/example/whostolemyfood/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/whostolemyfood/global/config/security/SecurityConfig.java
@@ -1,4 +1,22 @@
 package com.example.whostolemyfood.global.config.security;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
 public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable()) // 개발 단계 및 테스트 편의를 위해 CSRF 비활성화
+            .authorizeHttpRequests(auth -> auth
+                .anyRequest().permitAll() // TODO: [인증/인가] 나중에 권한별 접근 제어 로직 필요
+            );
+        return http.build();
+    }
 }

--- a/src/main/java/com/example/whostolemyfood/global/entity/BaseAuditEntity.java
+++ b/src/main/java/com/example/whostolemyfood/global/entity/BaseAuditEntity.java
@@ -1,4 +1,21 @@
 package com.example.whostolemyfood.global.entity;
 
-public class BaseAuditEntity {
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+
+import java.util.UUID;
+
+@Getter
+@MappedSuperclass
+public abstract class BaseAuditEntity extends BaseTimeEntity{
+    @CreatedBy
+    @Column(updatable = false, name = "created_by")
+    private UUID createdBy;
+
+    @LastModifiedBy
+    @Column(name = "updated_by")
+    private UUID updatedBy;
 }

--- a/src/main/java/com/example/whostolemyfood/global/entity/BaseSoftDeleteEntity.java
+++ b/src/main/java/com/example/whostolemyfood/global/entity/BaseSoftDeleteEntity.java
@@ -1,4 +1,22 @@
 package com.example.whostolemyfood.global.entity;
 
-public class BaseSoftDeleteEntity {
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@MappedSuperclass
+public abstract class BaseSoftDeleteEntity extends BaseAuditEntity {
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime deletedAt;
+
+    private UUID deletedBy;
+
+    public void delete(UUID deletedBy) {
+        this.deletedAt = LocalDateTime.now();
+        this.deletedBy = deletedBy;
+    }
 }

--- a/src/main/java/com/example/whostolemyfood/global/entity/BaseTimeEntity.java
+++ b/src/main/java/com/example/whostolemyfood/global/entity/BaseTimeEntity.java
@@ -1,4 +1,25 @@
 package com.example.whostolemyfood.global.entity;
 
-public class BaseTimeEntity {
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false, name = "created_at", columnDefinition = "TIMESTAMP")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(updatable = true, name = "updated_at", columnDefinition = "TIMESTAMP")
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/example/whostolemyfood/global/exception/ErrorResponse.java
+++ b/src/main/java/com/example/whostolemyfood/global/exception/ErrorResponse.java
@@ -1,4 +1,30 @@
 package com.example.whostolemyfood.global.exception;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class ErrorResponse {
+    private int status;
+    private String code;
+    private String message;
+    private List<FieldError> errors;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    public static class FieldError {
+        private String field;
+        private String value;
+        private String reason;
+    }
 }

--- a/src/main/java/com/example/whostolemyfood/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/whostolemyfood/global/exception/GlobalExceptionHandler.java
@@ -1,4 +1,48 @@
 package com.example.whostolemyfood.global.exception;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+
+@RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    /**
+     * Bean Validation 유효성 검사 실패 시 발생하는 예외 처리
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+        List<ErrorResponse.FieldError> fieldErrors = ex.getBindingResult().getFieldErrors().stream()
+                .map(error -> ErrorResponse.FieldError.builder()
+                        .field(error.getField())
+                        .value(String.valueOf(error.getRejectedValue()))
+                        .reason(error.getDefaultMessage())
+                        .build())
+                .toList();
+
+        ErrorResponse response = ErrorResponse.builder()
+                .status(400)
+                .code("VALIDATION_ERROR")
+                .message("입력값이 올바르지 않습니다.")
+                .errors(fieldErrors)
+                .build();
+
+        return ResponseEntity.badRequest().body(response);
+    }
+
+    /**
+     * 그 외 비즈니스 로직 오류 처리 (추후 CustomException 연동 예정)
+     */
+    @ExceptionHandler(IllegalStateException.class)
+    protected ResponseEntity<ErrorResponse> handleIllegalStateException(IllegalStateException ex) {
+        ErrorResponse response = ErrorResponse.builder()
+                .status(400)
+                .code("BUSINESS_ERROR")
+                .message(ex.getMessage())
+                .build();
+        return ResponseEntity.badRequest().body(response);
+    }
 }

--- a/src/main/java/com/example/whostolemyfood/order/application/service/OrderServiceV1.java
+++ b/src/main/java/com/example/whostolemyfood/order/application/service/OrderServiceV1.java
@@ -1,4 +1,147 @@
 package com.example.whostolemyfood.order.application.service;
 
+import com.example.whostolemyfood.order.domain.entity.OrderEntity;
+import com.example.whostolemyfood.order.domain.entity.OrderItemEntity;
+import com.example.whostolemyfood.order.domain.entity.OrderStatus;
+import com.example.whostolemyfood.order.domain.repository.OrderRepository;
+import com.example.whostolemyfood.order.presentation.dto.request.ReqCreateOrderDtoV1;
+import com.example.whostolemyfood.order.presentation.dto.response.ResCreateOrderDtoV1;
+import com.example.whostolemyfood.order.presentation.dto.response.ResGetOrderDtoV1;
+import com.example.whostolemyfood.order.presentation.dto.response.ResGetOrderListDtoV1;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class OrderServiceV1 {
+
+    private final OrderRepository orderRepository;
+
+    /**
+     * 주문 생성
+     */
+    @Transactional
+    public ResCreateOrderDtoV1 createOrder(ReqCreateOrderDtoV1 request) {
+        // TODO: [인증/인가] SecurityContext 기반 CUSTOMER ID 추출
+        UUID mockUserId = UUID.randomUUID(); 
+
+        int totalPrice = request.getOrderItems().stream()
+                .mapToInt(item -> item.getPriceAtOrder() * item.getQuantity())
+                .sum();
+
+        OrderEntity order = OrderEntity.builder()
+                .userId(mockUserId)
+                .storeId(request.getStoreId())
+                .addressId(request.getAddressId())
+                .request(request.getRequest())
+                .totalPrice(totalPrice)
+                .deliveryFee(3000) 
+                .status(OrderStatus.PENDING)
+                .build();
+
+        List<OrderItemEntity> orderItems = request.getOrderItems().stream()
+                .map(itemRequest -> OrderItemEntity.builder()
+                        .order(order)
+                        .menuId(itemRequest.getMenuId())
+                        .quantity(itemRequest.getQuantity())
+                        .priceAtOrder(itemRequest.getPriceAtOrder())
+                        .build())
+                .toList(); // .collect(Collectors.toList())에서 변경
+
+        order.getOrderItems().addAll(orderItems);
+
+        OrderEntity savedOrder = orderRepository.save(order);
+        return ResCreateOrderDtoV1.from(savedOrder);
+    }
+
+    /**
+     * 주문 단건 조회
+     */
+    public ResGetOrderDtoV1 getOrder(UUID orderId) {
+        OrderEntity order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new IllegalArgumentException("주문을 찾을 수 없습니다. ID: " + orderId));
+        return ResGetOrderDtoV1.from(order);
+    }
+
+    /**
+     * 주문 목록 조회 (페이징 및 검색)
+     * - storeId: 특정 가게 필터
+     * - isHidden: 숨김 여부 필터
+     */
+    public Page<ResGetOrderListDtoV1> getOrders(UUID storeId, Boolean isHidden, Pageable pageable) {
+        if (storeId != null && isHidden != null) {
+            return orderRepository.findAllByStoreIdAndIsHidden(storeId, isHidden, pageable).map(ResGetOrderListDtoV1::from);
+        } else if (storeId != null) {
+            return orderRepository.findAllByStoreId(storeId, pageable).map(ResGetOrderListDtoV1::from);
+        } else if (isHidden != null) {
+            return orderRepository.findAllByIsHidden(isHidden, pageable).map(ResGetOrderListDtoV1::from);
+        }
+        return orderRepository.findAll(pageable).map(ResGetOrderListDtoV1::from);
+    }
+
+    /**
+     * 주문 취소
+     */
+    @Transactional
+    public ResGetOrderDtoV1 cancelOrder(UUID orderId) {
+        OrderEntity order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new IllegalArgumentException("주문을 찾을 수 없습니다."));
+
+        LocalDateTime now = LocalDateTime.now();
+        Duration duration = Duration.between(order.getCreatedAt(), now);
+        if (duration.toMinutes() >= 5) {
+            throw new IllegalStateException("주문 생성 후 5분이 경과하여 취소할 수 없습니다.");
+        }
+
+        order.cancelOrder();
+        return ResGetOrderDtoV1.from(order);
+    }
+
+    /**
+     * 주문 수정(요청사항 수정)
+     */
+    @Transactional
+    public ResGetOrderDtoV1 updateOrderRequest(UUID orderId, String newRequest) {
+        OrderEntity order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new IllegalArgumentException("주문을 찾을 수 없습니다."));
+
+        // 상태 검증 로직은 OrderEntity.updateRequest 내부로 위임하여 중복 제거
+        order.updateRequest(newRequest); 
+        
+        return ResGetOrderDtoV1.from(order);
+    }
+
+    /**
+     * 주문 삭제 (Soft Delete)
+     */
+    @Transactional
+    public void deleteOrder(UUID orderId) {
+        OrderEntity order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new IllegalArgumentException("주문을 찾을 수 없습니다."));
+        order.markAsDeleted(UUID.randomUUID()); 
+    }
+
+    /**
+     * 주문 상태 변경 (사장님/관리자용)
+     */
+    @Transactional
+    public ResGetOrderDtoV1 updateOrderStatus(UUID orderId, OrderStatus nextStatus) {
+        OrderEntity order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new IllegalArgumentException("주문을 찾을 수 없습니다."));
+        
+        // TODO: [인가] OWNER, MANAGER 권한 및 상태 흐름 검증 로직 추가
+        order.updateStatus(nextStatus);
+        
+        return ResGetOrderDtoV1.from(order);
+    }
 }

--- a/src/main/java/com/example/whostolemyfood/order/domain/entity/OrderEntity.java
+++ b/src/main/java/com/example/whostolemyfood/order/domain/entity/OrderEntity.java
@@ -1,4 +1,84 @@
 package com.example.whostolemyfood.order.domain.entity;
 
-public class OrderEntity {
+import com.example.whostolemyfood.global.entity.BaseSoftDeleteEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_orders")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class OrderEntity extends BaseSoftDeleteEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID orderId;
+
+    @Column(nullable = false)
+    private UUID userId; // TODO: [인증/인가] SecurityContext 사용자 ID 연동
+
+    @Column(nullable = false)
+    private UUID storeId;
+
+    @Column(nullable = false)
+    private UUID addressId;
+
+    @Column(columnDefinition = "TEXT")
+    private String request;
+
+    @Column(nullable = false)
+    private Integer totalPrice;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private OrderStatus status;
+
+    @Column(nullable = false)
+    private Integer deliveryFee;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Boolean isDeleted = false;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Boolean isHidden = false;
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<OrderItemEntity> orderItems = new ArrayList<>();
+
+    // 데이터 저장(Persist) 전 초기 상태(PENDING) 설정
+    @PrePersist
+    protected void onCreate() {
+        if (status == null) {
+            status = OrderStatus.PENDING; 
+        }
+    }
+
+    public void cancelOrder() {
+        this.status = OrderStatus.CANCELLED;
+    }
+
+    // [비즈니스 로직] 객체 스스로 상태를 보호하도록 엔티티 내부에 핵심 로직 구현 (도메인 주도 설계)
+    public void updateRequest(String newRequest) {
+        if (this.getStatus() != OrderStatus.PENDING) {
+            throw new IllegalStateException("주문이 이미 수락되어 요청사항을 수정할 수 없습니다.");
+        }
+        this.request = newRequest;
+    }
+
+    public void updateStatus(OrderStatus nextStatus) {
+        this.status = nextStatus;
+    }
+
+    public void markAsDeleted(UUID deletedBy) {
+        this.isDeleted = true;
+        super.delete(deletedBy);
+    }
 }

--- a/src/main/java/com/example/whostolemyfood/order/domain/entity/OrderItemEntity.java
+++ b/src/main/java/com/example/whostolemyfood/order/domain/entity/OrderItemEntity.java
@@ -1,4 +1,45 @@
 package com.example.whostolemyfood.order.domain.entity;
 
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_order_item")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class OrderItemEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID orderItemId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private OrderEntity order;
+
+    @Column(nullable = false)
+    private UUID menuId;
+
+    @Column(nullable = false)
+    private Integer quantity;
+
+    @Column(nullable = false)
+    private Integer priceAtOrder; // 주문 시점의 가격
+
+    // [Audit] 필수 기능 명세에 따른 기록 전용 필드 (수정/삭제 미발생 도메인 특성 반영)
+    // 명세서 지침에 따라 BaseEntity 상속 없이 생성 정보만 직접 관리함
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    private UUID createdBy; // TODO: [인증/인가] 주문자 ID 연동
+
+    // 필수 기능 명세에 따라 데이터 저장 전 생성일(createdAt) 자동 기록
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now(); 
+    }
 }

--- a/src/main/java/com/example/whostolemyfood/order/domain/entity/OrderStatus.java
+++ b/src/main/java/com/example/whostolemyfood/order/domain/entity/OrderStatus.java
@@ -1,4 +1,21 @@
 package com.example.whostolemyfood.order.domain.entity;
 
+import lombok.Getter;
+
+@Getter
 public enum OrderStatus {
+    PENDING("주문요청"),      // CUSTOMER
+    ACCEPTED("주문수락"),     // OWNER
+    COOKING("조리완료"),      // OWNER
+    DELIVERING("배송수령"),   // OWNER
+    DELIVERED("배송완료"),    // OWNER
+    COMPLETED("주문완료"),    // OWNER
+    CANCELLED("주문취소");    // CUSTOMER (5분 이내) or MASTER
+
+    private final String description;
+
+    OrderStatus(String description) {
+        this.description = description;
+    }
 }
+

--- a/src/main/java/com/example/whostolemyfood/order/domain/repository/OrderItemRepository.java
+++ b/src/main/java/com/example/whostolemyfood/order/domain/repository/OrderItemRepository.java
@@ -1,4 +1,8 @@
 package com.example.whostolemyfood.order.domain.repository;
 
-public interface OrderItemRepository {
+import com.example.whostolemyfood.order.domain.entity.OrderItemEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.UUID;
+
+public interface OrderItemRepository extends JpaRepository<OrderItemEntity, UUID> {
 }

--- a/src/main/java/com/example/whostolemyfood/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/example/whostolemyfood/order/domain/repository/OrderRepository.java
@@ -1,4 +1,28 @@
 package com.example.whostolemyfood.order.domain.repository;
 
-public interface OrderRepository {
+import com.example.whostolemyfood.order.domain.entity.OrderEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.UUID;
+
+/**
+ * [Repository] 주문(Order) 도메인 전용 리포지토리 인터페이스
+ */
+public interface OrderRepository extends JpaRepository<OrderEntity, UUID> {
+    
+    /**
+     * 특정 가게의 주문 목록을 페이징하여 조회
+     */
+    Page<OrderEntity> findAllByStoreId(UUID storeId, Pageable pageable);
+
+    /**
+     * 가게 ID 및 숨김 여부에 따른 필터링 조회
+     */
+    Page<OrderEntity> findAllByStoreIdAndIsHidden(UUID storeId, Boolean isHidden, Pageable pageable);
+
+    /**
+     * 전체 주문 중 숨김 여부에 따른 필터링 조회
+     */
+    Page<OrderEntity> findAllByIsHidden(Boolean isHidden, Pageable pageable);
 }

--- a/src/main/java/com/example/whostolemyfood/order/presentation/controller/OrderControllerV1.java
+++ b/src/main/java/com/example/whostolemyfood/order/presentation/controller/OrderControllerV1.java
@@ -1,4 +1,128 @@
 package com.example.whostolemyfood.order.presentation.controller;
 
+import com.example.whostolemyfood.order.application.service.OrderServiceV1;
+import com.example.whostolemyfood.order.presentation.dto.request.ReqCreateOrderDtoV1;
+import com.example.whostolemyfood.order.presentation.dto.request.ReqUpdateOrderRequestDtoV1;
+import com.example.whostolemyfood.order.presentation.dto.request.ReqUpdateOrderStatusDtoV1;
+import com.example.whostolemyfood.order.presentation.dto.response.ResCreateOrderDtoV1;
+import com.example.whostolemyfood.order.presentation.dto.response.ResGetOrderDtoV1;
+import com.example.whostolemyfood.order.presentation.dto.response.ResGetOrderListDtoV1;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/orders")
+@RequiredArgsConstructor
+@Validated
 public class OrderControllerV1 {
+
+    private final OrderServiceV1 orderService;
+
+    /**
+     * 주문 생성 API
+     */
+    @PostMapping
+    public ResponseEntity<ResCreateOrderDtoV1> createOrder(@Valid @RequestBody ReqCreateOrderDtoV1 request) {
+        return ResponseEntity.ok(orderService.createOrder(request));
+    }
+
+    /**
+     * 주문 상세 조회 API
+     */
+    @GetMapping("/{orderId}")
+    public ResponseEntity<ResGetOrderDtoV1> getOrder(@PathVariable("orderId") UUID orderId) {
+        return ResponseEntity.ok(orderService.getOrder(orderId));
+    }
+
+    /**
+     * 주문 목록 조회 API (페이징 및 검색)
+     */
+    @GetMapping
+    public ResponseEntity<Page<ResGetOrderListDtoV1>> getOrders(
+            @RequestParam(name = "storeId", required = false) UUID storeId,
+            @RequestParam(name = "isHidden", required = false) Boolean isHidden,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        
+        int size = pageable.getPageSize();
+        if (size != 10 && size != 30 && size != 50) {
+            pageable = PageRequest.of(pageable.getPageNumber(), 10, pageable.getSort());
+        }
+        
+        return ResponseEntity.ok(orderService.getOrders(storeId, isHidden, pageable));
+    }
+
+    /**
+     * 주문 수정(요청사항 수정) API
+     */
+    @PutMapping("/{orderId}")
+    public ResponseEntity<ResGetOrderDtoV1> updateOrderRequest(
+            @PathVariable("orderId") UUID orderId, 
+            @Valid @RequestBody ReqUpdateOrderRequestDtoV1 requestDto) {
+        return ResponseEntity.ok(orderService.updateOrderRequest(orderId, requestDto.getRequest()));
+    }
+
+    /**
+     * 주문 취소 API
+     */
+    @PatchMapping("/{orderId}/cancel")
+    public ResponseEntity<ResGetOrderDtoV1> cancelOrder(@PathVariable("orderId") UUID orderId) {
+        return ResponseEntity.ok(orderService.cancelOrder(orderId));
+    }
+
+    /**
+     * 주문 상태 변경 API (사장님/관리자용)
+     */
+    @PatchMapping("/{orderId}/status")
+    public ResponseEntity<ResGetOrderDtoV1> updateOrderStatus(
+            @PathVariable("orderId") UUID orderId,
+            @Valid @RequestBody ReqUpdateOrderStatusDtoV1 request) {
+        return ResponseEntity.ok(orderService.updateOrderStatus(orderId, request.getStatus()));
+    }
+
+    /**
+     * 주문 삭제 API
+     */
+    @DeleteMapping("/{orderId}")
+    public ResponseEntity<Void> deleteOrder(@PathVariable("orderId") UUID orderId) {
+        orderService.deleteOrder(orderId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * [Exception Handler] 유효성 검사 에러 처리
+     */
+    @ExceptionHandler(org.springframework.web.bind.MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, Object>> handleValidationExceptions(
+            org.springframework.web.bind.MethodArgumentNotValidException ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("status", 400);
+        body.put("message", "VALIDATION_ERROR");
+        
+        List<Map<String, String>> errors = ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(error -> {
+                    Map<String, String> err = new HashMap<>();
+                    err.put("field", error.getField());
+                    err.put("message", error.getDefaultMessage());
+                    return err;
+                })
+                .toList();
+        
+        body.put("errors", errors);
+        return ResponseEntity.badRequest().body(body);
+    }
 }

--- a/src/main/java/com/example/whostolemyfood/order/presentation/dto/request/ReqCancelOrderDtoV1.java
+++ b/src/main/java/com/example/whostolemyfood/order/presentation/dto/request/ReqCancelOrderDtoV1.java
@@ -1,4 +1,11 @@
 package com.example.whostolemyfood.order.presentation.dto.request;
 
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class ReqCancelOrderDtoV1 {
+    private String cancelReason;
 }

--- a/src/main/java/com/example/whostolemyfood/order/presentation/dto/request/ReqCreateOrderDtoV1.java
+++ b/src/main/java/com/example/whostolemyfood/order/presentation/dto/request/ReqCreateOrderDtoV1.java
@@ -1,4 +1,44 @@
 package com.example.whostolemyfood.order.presentation.dto.request;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class ReqCreateOrderDtoV1 {
+
+    @NotNull(message = "가게 정보는 필수입니다.")
+    private UUID storeId;
+
+    @NotNull(message = "배송지 정보는 필수입니다.")
+    private UUID addressId;
+
+    private String request;
+
+    @Valid // List 내부의 OrderItemRequest 객체들까지 유효성 검사 수행
+    @NotEmpty(message = "주문 상품은 최소 하나 이상이어야 합니다.")
+    private List<OrderItemRequest> orderItems;
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    @Builder
+    public static class OrderItemRequest {
+        @NotNull(message = "메뉴 정보는 필수입니다.")
+        private UUID menuId;
+
+        @NotNull(message = "수량은 필수입니다.")
+        @Min(value = 1, message = "수량은 최소 1개 이상이어야 합니다.")
+        private Integer quantity;
+
+        @NotNull(message = "가격 정보는 필수입니다.")
+        private Integer priceAtOrder;
+    }
 }

--- a/src/main/java/com/example/whostolemyfood/order/presentation/dto/request/ReqUpdateOrderRequestDtoV1.java
+++ b/src/main/java/com/example/whostolemyfood/order/presentation/dto/request/ReqUpdateOrderRequestDtoV1.java
@@ -1,0 +1,13 @@
+package com.example.whostolemyfood.order.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ReqUpdateOrderRequestDtoV1 {
+    @NotBlank(message = "요청사항 내용은 비어있을 수 없습니다.")
+    private String request;
+}

--- a/src/main/java/com/example/whostolemyfood/order/presentation/dto/request/ReqUpdateOrderStatusDtoV1.java
+++ b/src/main/java/com/example/whostolemyfood/order/presentation/dto/request/ReqUpdateOrderStatusDtoV1.java
@@ -1,4 +1,14 @@
 package com.example.whostolemyfood.order.presentation.dto.request;
 
+import com.example.whostolemyfood.order.domain.entity.OrderStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class ReqUpdateOrderStatusDtoV1 {
+    @NotNull(message = "변경할 상태 정보는 필수입니다.")
+    private OrderStatus status;
 }

--- a/src/main/java/com/example/whostolemyfood/order/presentation/dto/response/ResCreateOrderDtoV1.java
+++ b/src/main/java/com/example/whostolemyfood/order/presentation/dto/response/ResCreateOrderDtoV1.java
@@ -1,4 +1,23 @@
 package com.example.whostolemyfood.order.presentation.dto.response;
 
+import com.example.whostolemyfood.order.domain.entity.OrderEntity;
+import lombok.*;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class ResCreateOrderDtoV1 {
+    private UUID orderId;
+    private Integer totalPrice;
+    private String message;
+
+    public static ResCreateOrderDtoV1 from(OrderEntity order) {
+        return ResCreateOrderDtoV1.builder()
+                .orderId(order.getOrderId())
+                .totalPrice(order.getTotalPrice())
+                .message("주문이 성공적으로 생성되었습니다.")
+                .build();
+    }
 }

--- a/src/main/java/com/example/whostolemyfood/order/presentation/dto/response/ResGetOrderDtoV1.java
+++ b/src/main/java/com/example/whostolemyfood/order/presentation/dto/response/ResGetOrderDtoV1.java
@@ -1,4 +1,60 @@
 package com.example.whostolemyfood.order.presentation.dto.response;
 
+import com.example.whostolemyfood.order.domain.entity.OrderEntity;
+import com.example.whostolemyfood.order.domain.entity.OrderStatus;
+import lombok.*;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class ResGetOrderDtoV1 {
+
+    private UUID orderId;
+    private UUID userId;
+    private UUID storeId;
+    private UUID addressId;
+    private String request;
+    private Integer totalPrice;
+    private OrderStatus status;
+    private Integer deliveryFee;
+    private LocalDateTime createdAt;
+    private List<OrderItemResponse> orderItems;
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    @Builder
+    public static class OrderItemResponse {
+        private UUID orderItemId;
+        private UUID menuId;
+        private Integer quantity;
+        private Integer priceAtOrder;
+    }
+
+    public static ResGetOrderDtoV1 from(OrderEntity order) {
+        return ResGetOrderDtoV1.builder()
+                .orderId(order.getOrderId())
+                .userId(order.getUserId())
+                .storeId(order.getStoreId())
+                .addressId(order.getAddressId())
+                .request(order.getRequest())
+                .totalPrice(order.getTotalPrice())
+                .status(order.getStatus())
+                .deliveryFee(order.getDeliveryFee())
+                .createdAt(order.getCreatedAt())
+                .orderItems(order.getOrderItems().stream()
+                        .map(item -> OrderItemResponse.builder()
+                                .orderItemId(item.getOrderItemId())
+                                .menuId(item.getMenuId())
+                                .quantity(item.getQuantity())
+                                .priceAtOrder(item.getPriceAtOrder())
+                                .build())
+                        .collect(Collectors.toList()))
+                .build();
+    }
 }

--- a/src/main/java/com/example/whostolemyfood/order/presentation/dto/response/ResGetOrderListDtoV1.java
+++ b/src/main/java/com/example/whostolemyfood/order/presentation/dto/response/ResGetOrderListDtoV1.java
@@ -1,4 +1,37 @@
 package com.example.whostolemyfood.order.presentation.dto.response;
 
+import com.example.whostolemyfood.order.domain.entity.OrderEntity;
+import com.example.whostolemyfood.order.domain.entity.OrderStatus;
+import lombok.*;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class ResGetOrderListDtoV1 {
+    private UUID orderId;
+    private UUID userId;
+    private UUID storeId;
+    private UUID addressId;
+    private String request;
+    private Integer totalPrice;
+    private Integer deliveryFee;
+    private OrderStatus status;
+    private LocalDateTime createdAt;
+
+    public static ResGetOrderListDtoV1 from(OrderEntity order) {
+        return ResGetOrderListDtoV1.builder()
+                .orderId(order.getOrderId())
+                .userId(order.getUserId())
+                .storeId(order.getStoreId())
+                .addressId(order.getAddressId())
+                .request(order.getRequest())
+                .totalPrice(order.getTotalPrice())
+                .deliveryFee(order.getDeliveryFee())
+                .status(order.getStatus())
+                .createdAt(order.getCreatedAt())
+                .build();
+    }
 }

--- a/src/test/java/com/example/whostolemyfood/order/OrderControllerTest.java
+++ b/src/test/java/com/example/whostolemyfood/order/OrderControllerTest.java
@@ -1,0 +1,69 @@
+package com.example.whostolemyfood.order;
+
+import com.example.whostolemyfood.global.exception.GlobalExceptionHandler;
+import com.example.whostolemyfood.order.application.service.OrderServiceV1;
+import com.example.whostolemyfood.order.presentation.controller.OrderControllerV1;
+import com.example.whostolemyfood.order.presentation.dto.request.ReqCreateOrderDtoV1;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(OrderControllerV1.class)
+@Import(GlobalExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false)
+public class OrderControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private OrderServiceV1 orderService;
+
+    @Test
+    @DisplayName("잘못된 입력값(수량 0)으로 주문 생성 시 400 에러를 반환해야 함")
+    void validationErrorTest() throws Exception {
+        // Given: 수량이 0인 잘못된 요청 데이터를 만듭니다.
+        ReqCreateOrderDtoV1 invalidRequest = ReqCreateOrderDtoV1.builder()
+                .storeId(UUID.randomUUID())
+                .addressId(UUID.randomUUID())
+                .orderItems(List.of(
+                        ReqCreateOrderDtoV1.OrderItemRequest.builder()
+                                .menuId(UUID.randomUUID())
+                                .quantity(0) // 유효성 검사 위반
+                                .priceAtOrder(10000)
+                                .build()
+                ))
+                .build();
+
+        // When & Then
+        mockMvc.perform(post("/api/orders")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequest)))
+                .andDo(print()) // 콘솔에 상세 로그를 출력
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("VALIDATION_ERROR")) // code -> message 로 변경
+                .andExpect(jsonPath("$.errors[0].field").value("orderItems[0].quantity"))
+                .andExpect(jsonPath("$.errors[0].message").value("수량은 최소 1개 이상이어야 합니다.")); // reason -> message 로 변경
+
+        verifyNoInteractions(orderService);
+    }
+}

--- a/src/test/java/com/example/whostolemyfood/order/OrderRepositoryTest.java
+++ b/src/test/java/com/example/whostolemyfood/order/OrderRepositoryTest.java
@@ -1,0 +1,76 @@
+package com.example.whostolemyfood.order;
+
+import com.example.whostolemyfood.global.config.JpaAuditingConfig;
+import com.example.whostolemyfood.order.domain.entity.OrderEntity;
+import com.example.whostolemyfood.order.domain.entity.OrderStatus;
+import com.example.whostolemyfood.order.domain.repository.OrderRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class OrderRepositoryTest {
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Test
+    @DisplayName("주문 저장 및 조회 시 UUID PK와 상태값이 정확해야 함")
+    void saveAndFindOrderTest() {
+        OrderEntity order = createOrder(UUID.randomUUID());
+        OrderEntity savedOrder = orderRepository.save(order);
+
+        OrderEntity foundOrder = orderRepository.findById(savedOrder.getOrderId()).orElseThrow();
+        assertThat(foundOrder.getOrderId()).isNotNull();
+        assertThat(foundOrder.getStatus()).isEqualTo(OrderStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("특정 가게의 주문만 필터링하여 조회할 수 있어야 함")
+    void findAllByStoreIdTest() {
+        UUID storeA = UUID.randomUUID();
+        UUID storeB = UUID.randomUUID();
+        
+        orderRepository.save(createOrder(storeA));
+        orderRepository.save(createOrder(storeA));
+        orderRepository.save(createOrder(storeB));
+
+        Page<OrderEntity> orders = orderRepository.findAllByStoreId(storeA, PageRequest.of(0, 10));
+        assertThat(orders.getTotalElements()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("주문 삭제 시 물리 삭제가 아닌 Soft Delete(isDeleted=true)가 되어야 함")
+    void softDeleteTest() {
+        OrderEntity order = orderRepository.save(createOrder(UUID.randomUUID()));
+        
+        order.markAsDeleted(UUID.randomUUID());
+        orderRepository.saveAndFlush(order);
+
+        OrderEntity foundOrder = orderRepository.findById(order.getOrderId()).orElseThrow();
+        assertThat(foundOrder.getIsDeleted()).isTrue();
+        assertThat(foundOrder.getDeletedAt()).isNotNull();
+    }
+
+    private OrderEntity createOrder(UUID storeId) {
+        return OrderEntity.builder()
+                .userId(UUID.randomUUID())
+                .storeId(storeId)
+                .addressId(UUID.randomUUID())
+                .totalPrice(10000)
+                .deliveryFee(3000)
+                .status(OrderStatus.PENDING)
+                .build();
+    }
+}

--- a/src/test/java/com/example/whostolemyfood/order/OrderServiceTest.java
+++ b/src/test/java/com/example/whostolemyfood/order/OrderServiceTest.java
@@ -1,0 +1,87 @@
+package com.example.whostolemyfood.order;
+
+import com.example.whostolemyfood.order.application.service.OrderServiceV1;
+import com.example.whostolemyfood.order.domain.entity.OrderEntity;
+import com.example.whostolemyfood.order.domain.entity.OrderStatus;
+import com.example.whostolemyfood.order.domain.repository.OrderRepository;
+import com.example.whostolemyfood.order.presentation.dto.request.ReqCreateOrderDtoV1;
+import com.example.whostolemyfood.order.presentation.dto.response.ResCreateOrderDtoV1;
+import com.example.whostolemyfood.order.presentation.dto.response.ResGetOrderDtoV1;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class OrderServiceTest {
+
+    @InjectMocks
+    private OrderServiceV1 orderService;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Test
+    @DisplayName("주문 생성 시 서버에서 상품별 총 결제 금액을 정확히 계산해야 함")
+    void createOrderPriceCalculationTest() {
+        ReqCreateOrderDtoV1 request = ReqCreateOrderDtoV1.builder()
+                .storeId(UUID.randomUUID())
+                .addressId(UUID.randomUUID())
+                .orderItems(List.of(
+                        ReqCreateOrderDtoV1.OrderItemRequest.builder().priceAtOrder(20000).quantity(1).build(),
+                        ReqCreateOrderDtoV1.OrderItemRequest.builder().priceAtOrder(5000).quantity(2).build()
+                ))
+                .build();
+
+        given(orderRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+
+        ResCreateOrderDtoV1 response = orderService.createOrder(request);
+
+        // 20000*1 + 5000*2 = 30000
+        assertThat(response.getTotalPrice()).isEqualTo(30000);
+    }
+
+    @Test
+    @DisplayName("주문 생성 후 5분이 경과하면 취소가 불가능해야 함 (IllegalStateException)")
+    void cancelOrderTimeLimitTest() {
+        UUID orderId = UUID.randomUUID();
+        OrderEntity oldOrder = OrderEntity.builder()
+                .orderId(orderId)
+                .status(OrderStatus.PENDING)
+                .build();
+        
+        // 생성 시간을 6분 전으로 강제 설정
+        ReflectionTestUtils.setField(oldOrder, "createdAt", LocalDateTime.now().minusMinutes(6));
+        
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(oldOrder));
+
+        assertThrows(IllegalStateException.class, () -> orderService.cancelOrder(orderId));
+    }
+
+    @Test
+    @DisplayName("수락된 주문(ACCEPTED)은 요청사항을 수정할 수 없어야 함 (도메인 보호 로직)")
+    void updateOrderRequestStatusCheckTest() {
+        UUID orderId = UUID.randomUUID();
+        OrderEntity acceptedOrder = OrderEntity.builder()
+                .orderId(orderId)
+                .status(OrderStatus.ACCEPTED)
+                .build();
+
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(acceptedOrder));
+
+        assertThrows(IllegalStateException.class, () -> orderService.updateOrderRequest(orderId, "수정요청"));
+    }
+}


### PR DESCRIPTION
<br/>

## ✨  제목 : Feat/#5 주문 도메인 CRUD 개발 및 테스트 코드 작성 #5

<br/>

## 🔨 작업 내용

- 주문(Order) 엔티티 정의 및 DB 매핑 (Soft Delete 포함)
- 주문 상품(OrderItem) 엔티티 정의
- 주문 생성 API / 주문 상세 조회 API 
- 주문 목록 조회 및 페이징 처리 (10/30/50건 제한)
- 주문 취소 기능 (생성 후 5분 이내 제한)
- 주문 상태 변경 API 
- 주문 요청사항 수정 API (PENDING 상태 한정)
- 주문 삭제(Soft Delete) 기능 


## 🌐 Global 추가 내용

- JPA Auditing 추가 및 BaseEntity 구조 
  * 생성/수정 시간 및 Soft Delete 기능을 일일이 작성하는 중복을 피하고 자동화하기 위해서 추가했습니다. (Base 코드들은 승민님 코드 그대로 가져와서 썼습니다.)
- GlobalExceptionHandler 
  * 주문 생성 시 수량 미달 등 유효성 검사 에러를 사용자에게 일관된 JSON 규격으로 응답하여 가독성을 높이기 위해 사용했습니다.
- Security Config 설정
  * 주문 API를 개발하는 과정에서 발생한 권한 차단(403) 문제를 해결하고, Postman 테스트를 위해 필요해서 추가했습니다. 개발 초기 단계에서 API를 테스트할 수 있도록 기초적인 접근 제어 설정이 필요해서 임시로 만들었습니다.
  
<br/>

## 🍻 실행된 화면(postman에서 테스트한 것 캡쳐해서 올려주세요 성공, 예외처리되는것까지)

- 주문 생성
<img width="1451" height="1093" alt="image" src="https://github.com/user-attachments/assets/ff3b3ca4-03e8-4488-8323-9f3c07f42708" />

- 주문 조회 (페이징, 전체 조회)
<img width="1440" height="1175" alt="image" src="https://github.com/user-attachments/assets/a1fa360e-23b1-408b-8309-a6db7081edcf" />
<img width="1415" height="1481" alt="image" src="https://github.com/user-attachments/assets/35945486-a998-4206-ac74-e971bc73743e" />
<img width="1415" height="1530" alt="image" src="https://github.com/user-attachments/assets/5e6c4ab3-7b36-415b-8a88-f31afc042a4b" />

- 주문 상태 변경 
<img width="1406" height="1234" alt="image" src="https://github.com/user-attachments/assets/8d08f8be-e156-4df2-8c4f-7aa899c76ed5" />

- 주문 요청 사항 수정
<img width="1429" height="756" alt="image" src="https://github.com/user-attachments/assets/beb22645-e304-423f-89c5-b19d021da650" />
<img width="1413" height="990" alt="image" src="https://github.com/user-attachments/assets/877311a8-9a05-4620-bbb1-7327f952ac34" />

- 주문 취소
<img width="1535" height="678" alt="image" src="https://github.com/user-attachments/assets/fc1a4ceb-8fab-49f4-ad21-fa067f887617" />
<img width="1551" height="965" alt="image" src="https://github.com/user-attachments/assets/d6d3fe84-f65a-4d5b-8837-bc5cb270620e" />

- 주문 삭제 
<img width="1502" height="610" alt="image" src="https://github.com/user-attachments/assets/abc4e80f-1fe1-4238-8d93-3633cf0e1b08" />


<br/>


## 🔎   앞으로의 과제

 - 인증 연동: 서비스(OrderServiceV1)의 mockUserId를 SecurityContext에서 추출한 실제 유저 UUID로 교체하기
 - 작성자 자동화: BaseAuditEntity의 createdBy 필드에 현재 로그인한 사용자 정보가 자동으로 기록되는 기능 연결 필요
 - 권한 필터링: 리포지토리 조회 시 로그인 유저의 권한(고객/사장님)에 따라 본인 데이터만 나오도록 필터링 로직 추가
 - 상태 검증: OrderEntity 내에 비정상적인 상태 흐름(예: 배달 완료 후 취소 불가 등)을 막는 상태 머신 검증 로직 보강
 - [도전] QueryDSL 도입: 향후 주문 일시, 상태, 가게명 등 복합 조건 검색 성능 최적화를 위해 QueryDSL 적용
 - [도전] 배달비 정책 자동화: 현재 고정값(3,000원)으로 설정한 배달비를 배송 거리나 가게 설정에 따라 자동 계산되도록 연동


  <br/>

