### PR TITLE
 Refactor/#15 주문(Order) 도메인 논리 삭제 데이터 노출 방지 및 주문 상태 변경 방어 로직 강화

### DIFF
--- a/src/main/java/com/example/whostolemyfood/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/whostolemyfood/global/exception/GlobalExceptionHandler.java
@@ -34,7 +34,20 @@ public class GlobalExceptionHandler {
     }
 
     /**
-     * 그 외 비즈니스 로직 오류 처리 (추후 CustomException 연동 예정)
+     * 존재하지 않는 데이터 요청이나 잘못된 인자 값 처리
+     */
+    @ExceptionHandler(IllegalArgumentException.class)
+    protected ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException ex) {
+        ErrorResponse response = ErrorResponse.builder()
+                .status(400)
+                .code("BUSINESS_ERROR")
+                .message(ex.getMessage())
+                .build();
+        return ResponseEntity.badRequest().body(response);
+    }
+
+    /**
+     * 그 외 비즈니스 로직 오류 처리 (주문 상태 위반 등)
      */
     @ExceptionHandler(IllegalStateException.class)
     protected ResponseEntity<ErrorResponse> handleIllegalStateException(IllegalStateException ex) {

--- a/src/main/java/com/example/whostolemyfood/order/application/service/OrderServiceV1.java
+++ b/src/main/java/com/example/whostolemyfood/order/application/service/OrderServiceV1.java
@@ -18,7 +18,6 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -26,28 +25,35 @@ import java.util.stream.Collectors;
 public class OrderServiceV1 {
 
     private final OrderRepository orderRepository;
+    // TODO: [미래대비] 타 도메인 연동을 위한 레포지토리 미리 선언
+    // private final StoreRepository storeRepository;
+    // private final AddressRepository addressRepository;
 
     /**
-     * 주문 생성
+     * 주문 생성 (음식값 + 배달비 합산 로직 포함)
      */
     @Transactional
     public ResCreateOrderDtoV1 createOrder(ReqCreateOrderDtoV1 request) {
         // TODO: [인증/인가] SecurityContext 기반 CUSTOMER ID 추출
         UUID mockUserId = UUID.randomUUID(); 
 
+        // TODO: [미래대비] Store, Address 존재 여부 검증 로직이 들어올 자리
+        // storeRepository.findById(request.getStoreId()).orElseThrow(...);
+        // addressRepository.findById(request.getAddressId()).orElseThrow(...);
+
         int itemTotalPrice = request.getOrderItems().stream()
                 .mapToInt(item -> item.getPriceAtOrder() * item.getQuantity())
                 .sum();
 
-        int deliveryFee = 3000; // 기본 배달비
-        int finalTotalPrice = itemTotalPrice + deliveryFee; // 최종 합산 금액
+        int deliveryFee = 3000; 
+        int finalTotalPrice = itemTotalPrice + deliveryFee;
 
         OrderEntity order = OrderEntity.builder()
                 .userId(mockUserId)
                 .storeId(request.getStoreId())
                 .addressId(request.getAddressId())
                 .request(request.getRequest())
-                .totalPrice(finalTotalPrice) // 결제 시 이 필드만 쓸 수 있도록 수정
+                .totalPrice(finalTotalPrice)
                 .deliveryFee(deliveryFee)
                 .status(OrderStatus.PENDING)
                 .build();
@@ -59,7 +65,7 @@ public class OrderServiceV1 {
                         .quantity(itemRequest.getQuantity())
                         .priceAtOrder(itemRequest.getPriceAtOrder())
                         .build())
-                .toList(); // .collect(Collectors.toList())에서 변경
+                .toList();
 
         order.getOrderItems().addAll(orderItems);
 
@@ -68,37 +74,37 @@ public class OrderServiceV1 {
     }
 
     /**
-     * 주문 단건 조회
+     * 주문 단건 조회 (삭제된 주문은 필터링)
      */
     public ResGetOrderDtoV1 getOrder(UUID orderId) {
         OrderEntity order = orderRepository.findById(orderId)
-                .orElseThrow(() -> new IllegalArgumentException("주문을 찾을 수 없습니다. ID: " + orderId));
+                .filter(o -> !o.getIsDeleted())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않거나 삭제된 주문입니다. ID: " + orderId));
         return ResGetOrderDtoV1.from(order);
     }
 
     /**
-     * 주문 목록 조회 (페이징 및 검색)
-     * - storeId: 특정 가게 필터
-     * - isHidden: 숨김 여부 필터
+     * 주문 목록 조회 (페이징 및 검색 - 삭제된 데이터 제외)
      */
     public Page<ResGetOrderListDtoV1> getOrders(UUID storeId, Boolean isHidden, Pageable pageable) {
         if (storeId != null && isHidden != null) {
-            return orderRepository.findAllByStoreIdAndIsHidden(storeId, isHidden, pageable).map(ResGetOrderListDtoV1::from);
+            return orderRepository.findAllByStoreIdAndIsHiddenAndIsDeletedFalse(storeId, isHidden, pageable).map(ResGetOrderListDtoV1::from);
         } else if (storeId != null) {
-            return orderRepository.findAllByStoreId(storeId, pageable).map(ResGetOrderListDtoV1::from);
+            return orderRepository.findAllByStoreIdAndIsDeletedFalse(storeId, pageable).map(ResGetOrderListDtoV1::from);
         } else if (isHidden != null) {
-            return orderRepository.findAllByIsHidden(isHidden, pageable).map(ResGetOrderListDtoV1::from);
+            return orderRepository.findAllByIsHiddenAndIsDeletedFalse(isHidden, pageable).map(ResGetOrderListDtoV1::from);
         }
-        return orderRepository.findAll(pageable).map(ResGetOrderListDtoV1::from);
+        return orderRepository.findAllByIsDeletedFalse(pageable).map(ResGetOrderListDtoV1::from);
     }
 
     /**
-     * 주문 취소
+     * 주문 취소 (5분 제한 및 삭제 상태 체크)
      */
     @Transactional
     public ResGetOrderDtoV1 cancelOrder(UUID orderId) {
         OrderEntity order = orderRepository.findById(orderId)
-                .orElseThrow(() -> new IllegalArgumentException("주문을 찾을 수 없습니다."));
+                .filter(o -> !o.getIsDeleted())
+                .orElseThrow(() -> new IllegalArgumentException("주문을 찾을 수 없거나 이미 삭제되었습니다."));
 
         LocalDateTime now = LocalDateTime.now();
         Duration duration = Duration.between(order.getCreatedAt(), now);
@@ -111,27 +117,16 @@ public class OrderServiceV1 {
     }
 
     /**
-     * 주문 수정(요청사항 수정)
+     * 주문 수정(요청사항 수정 - PENDING 상태만 가능)
      */
     @Transactional
     public ResGetOrderDtoV1 updateOrderRequest(UUID orderId, String newRequest) {
         OrderEntity order = orderRepository.findById(orderId)
-                .orElseThrow(() -> new IllegalArgumentException("주문을 찾을 수 없습니다."));
+                .filter(o -> !o.getIsDeleted())
+                .orElseThrow(() -> new IllegalArgumentException("주문을 찾을 수 없거나 이미 삭제되었습니다."));
 
-        // 상태 검증 로직은 OrderEntity.updateRequest 내부로 위임하여 중복 제거
         order.updateRequest(newRequest); 
-        
         return ResGetOrderDtoV1.from(order);
-    }
-
-    /**
-     * 주문 삭제 (Soft Delete)
-     */
-    @Transactional
-    public void deleteOrder(UUID orderId) {
-        OrderEntity order = orderRepository.findById(orderId)
-                .orElseThrow(() -> new IllegalArgumentException("주문을 찾을 수 없습니다."));
-        order.markAsDeleted(UUID.randomUUID()); 
     }
 
     /**
@@ -140,11 +135,33 @@ public class OrderServiceV1 {
     @Transactional
     public ResGetOrderDtoV1 updateOrderStatus(UUID orderId, OrderStatus nextStatus) {
         OrderEntity order = orderRepository.findById(orderId)
-                .orElseThrow(() -> new IllegalArgumentException("주문을 찾을 수 없습니다."));
+                .filter(o -> !o.getIsDeleted())
+                .orElseThrow(() -> new IllegalArgumentException("주문을 찾을 수 없거나 이미 삭제되었습니다."));
         
-        // TODO: [인가] OWNER, MANAGER 권한 및 상태 흐름 검증 로직 추가
+        // [비즈니스 검증] 이미 취소되거나 완료된 주문은 상태 변경 불가
+        if (order.getStatus() == OrderStatus.CANCELLED || 
+            order.getStatus() == OrderStatus.DELIVERED || 
+            order.getStatus() == OrderStatus.COMPLETED) {
+            throw new IllegalStateException("이미 최종 상태(취소/완료)에 도달한 주문은 상태를 변경할 수 없습니다.");
+        }
+
         order.updateStatus(nextStatus);
-        
         return ResGetOrderDtoV1.from(order);
+    }
+
+    /**
+     * 주문 삭제 (Soft Delete 및 비즈니스 검증)
+     */
+    @Transactional
+    public void deleteOrder(UUID orderId) {
+        OrderEntity order = orderRepository.findById(orderId)
+                .filter(o -> !o.getIsDeleted())
+                .orElseThrow(() -> new IllegalArgumentException("이미 삭제되었거나 존재하지 않는 주문입니다."));
+
+        if (order.getStatus() == OrderStatus.DELIVERED || order.getStatus() == OrderStatus.COMPLETED) {
+            throw new IllegalStateException("배달이 완료된 주문은 삭제할 수 없습니다.");
+        }
+
+        order.markAsDeleted(UUID.randomUUID()); 
     }
 }

--- a/src/main/java/com/example/whostolemyfood/order/application/service/OrderServiceV1.java
+++ b/src/main/java/com/example/whostolemyfood/order/application/service/OrderServiceV1.java
@@ -35,17 +35,20 @@ public class OrderServiceV1 {
         // TODO: [인증/인가] SecurityContext 기반 CUSTOMER ID 추출
         UUID mockUserId = UUID.randomUUID(); 
 
-        int totalPrice = request.getOrderItems().stream()
+        int itemTotalPrice = request.getOrderItems().stream()
                 .mapToInt(item -> item.getPriceAtOrder() * item.getQuantity())
                 .sum();
+
+        int deliveryFee = 3000; // 기본 배달비
+        int finalTotalPrice = itemTotalPrice + deliveryFee; // 최종 합산 금액
 
         OrderEntity order = OrderEntity.builder()
                 .userId(mockUserId)
                 .storeId(request.getStoreId())
                 .addressId(request.getAddressId())
                 .request(request.getRequest())
-                .totalPrice(totalPrice)
-                .deliveryFee(3000) 
+                .totalPrice(finalTotalPrice) // 결제 시 이 필드만 쓸 수 있도록 수정
+                .deliveryFee(deliveryFee)
                 .status(OrderStatus.PENDING)
                 .build();
 

--- a/src/main/java/com/example/whostolemyfood/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/example/whostolemyfood/order/domain/repository/OrderRepository.java
@@ -8,21 +8,27 @@ import java.util.UUID;
 
 /**
  * [Repository] 주문(Order) 도메인 전용 리포지토리 인터페이스
+ * - 실무 표준에 따라 모든 조회 시 논리 삭제(isDeleted = false)된 데이터만 필터링합니다.
  */
 public interface OrderRepository extends JpaRepository<OrderEntity, UUID> {
     
     /**
-     * 특정 가게의 주문 목록을 페이징하여 조회
+     * 기본 페이징 조회 (삭제된 데이터 제외)
      */
-    Page<OrderEntity> findAllByStoreId(UUID storeId, Pageable pageable);
+    Page<OrderEntity> findAllByIsDeletedFalse(Pageable pageable);
 
     /**
-     * 가게 ID 및 숨김 여부에 따른 필터링 조회
+     * 특정 가게의 활성 주문 목록 조회
      */
-    Page<OrderEntity> findAllByStoreIdAndIsHidden(UUID storeId, Boolean isHidden, Pageable pageable);
+    Page<OrderEntity> findAllByStoreIdAndIsDeletedFalse(UUID storeId, Pageable pageable);
 
     /**
-     * 전체 주문 중 숨김 여부에 따른 필터링 조회
+     * 가게 ID 및 숨김 여부에 따른 필터링 조회 (삭제된 데이터 제외)
      */
-    Page<OrderEntity> findAllByIsHidden(Boolean isHidden, Pageable pageable);
+    Page<OrderEntity> findAllByStoreIdAndIsHiddenAndIsDeletedFalse(UUID storeId, Boolean isHidden, Pageable pageable);
+
+    /**
+     * 전체 주문 중 숨김 여부에 따른 필터링 조회 (삭제된 데이터 제외)
+     */
+    Page<OrderEntity> findAllByIsHiddenAndIsDeletedFalse(Boolean isHidden, Pageable pageable);
 }

--- a/src/main/java/com/example/whostolemyfood/order/presentation/controller/OrderControllerV1.java
+++ b/src/main/java/com/example/whostolemyfood/order/presentation/controller/OrderControllerV1.java
@@ -10,7 +10,6 @@ import com.example.whostolemyfood.order.presentation.dto.response.ResGetOrderLis
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -18,9 +17,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 @RestController
@@ -58,7 +54,7 @@ public class OrderControllerV1 {
         
         int size = pageable.getPageSize();
         if (size != 10 && size != 30 && size != 50) {
-            pageable = PageRequest.of(pageable.getPageNumber(), 10, pageable.getSort());
+            pageable = org.springframework.data.domain.PageRequest.of(pageable.getPageNumber(), 10, pageable.getSort());
         }
         
         return ResponseEntity.ok(orderService.getOrders(storeId, isHidden, pageable));
@@ -99,30 +95,5 @@ public class OrderControllerV1 {
     public ResponseEntity<Void> deleteOrder(@PathVariable("orderId") UUID orderId) {
         orderService.deleteOrder(orderId);
         return ResponseEntity.noContent().build();
-    }
-
-    /**
-     * [Exception Handler] 유효성 검사 에러 처리
-     */
-    @ExceptionHandler(org.springframework.web.bind.MethodArgumentNotValidException.class)
-    public ResponseEntity<Map<String, Object>> handleValidationExceptions(
-            org.springframework.web.bind.MethodArgumentNotValidException ex) {
-        Map<String, Object> body = new HashMap<>();
-        body.put("status", 400);
-        body.put("message", "VALIDATION_ERROR");
-        
-        List<Map<String, String>> errors = ex.getBindingResult()
-                .getFieldErrors()
-                .stream()
-                .map(error -> {
-                    Map<String, String> err = new HashMap<>();
-                    err.put("field", error.getField());
-                    err.put("message", error.getDefaultMessage());
-                    return err;
-                })
-                .toList();
-        
-        body.put("errors", errors);
-        return ResponseEntity.badRequest().body(body);
     }
 }

--- a/src/main/java/com/example/whostolemyfood/order/presentation/dto/response/ResCreateOrderDtoV1.java
+++ b/src/main/java/com/example/whostolemyfood/order/presentation/dto/response/ResCreateOrderDtoV1.java
@@ -1,7 +1,9 @@
 package com.example.whostolemyfood.order.presentation.dto.response;
 
 import com.example.whostolemyfood.order.domain.entity.OrderEntity;
+import com.example.whostolemyfood.order.domain.entity.OrderStatus;
 import lombok.*;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Getter
@@ -11,12 +13,18 @@ import java.util.UUID;
 public class ResCreateOrderDtoV1 {
     private UUID orderId;
     private Integer totalPrice;
+    private Integer deliveryFee;
+    private OrderStatus status;
+    private LocalDateTime createdAt;
     private String message;
 
     public static ResCreateOrderDtoV1 from(OrderEntity order) {
         return ResCreateOrderDtoV1.builder()
                 .orderId(order.getOrderId())
                 .totalPrice(order.getTotalPrice())
+                .deliveryFee(order.getDeliveryFee())
+                .status(order.getStatus())
+                .createdAt(order.getCreatedAt())
                 .message("주문이 성공적으로 생성되었습니다.")
                 .build();
     }

--- a/src/test/java/com/example/whostolemyfood/order/OrderControllerTest.java
+++ b/src/test/java/com/example/whostolemyfood/order/OrderControllerTest.java
@@ -2,8 +2,13 @@ package com.example.whostolemyfood.order;
 
 import com.example.whostolemyfood.global.exception.GlobalExceptionHandler;
 import com.example.whostolemyfood.order.application.service.OrderServiceV1;
+import com.example.whostolemyfood.order.domain.entity.OrderStatus;
 import com.example.whostolemyfood.order.presentation.controller.OrderControllerV1;
 import com.example.whostolemyfood.order.presentation.dto.request.ReqCreateOrderDtoV1;
+import com.example.whostolemyfood.order.presentation.dto.request.ReqUpdateOrderRequestDtoV1;
+import com.example.whostolemyfood.order.presentation.dto.request.ReqUpdateOrderStatusDtoV1;
+import com.example.whostolemyfood.order.presentation.dto.response.ResCreateOrderDtoV1;
+import com.example.whostolemyfood.order.presentation.dto.response.ResGetOrderDtoV1;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -11,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -18,8 +24,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.List;
 import java.util.UUID;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -39,31 +47,103 @@ public class OrderControllerTest {
     private OrderServiceV1 orderService;
 
     @Test
-    @DisplayName("잘못된 입력값(수량 0)으로 주문 생성 시 400 에러를 반환해야 함")
+    @DisplayName("[성공] 주문 생성 API 호출 시 200 OK를 반환해야 함")
+    void createOrderApiTest() throws Exception {
+        ReqCreateOrderDtoV1 request = ReqCreateOrderDtoV1.builder()
+                .storeId(UUID.randomUUID()).addressId(UUID.randomUUID())
+                .orderItems(List.of(ReqCreateOrderDtoV1.OrderItemRequest.builder().menuId(UUID.randomUUID()).quantity(1).priceAtOrder(10000).build()))
+                .build();
+        ResCreateOrderDtoV1 response = ResCreateOrderDtoV1.builder().orderId(UUID.randomUUID()).totalPrice(13000).build();
+        given(orderService.createOrder(any())).willReturn(response);
+
+        mockMvc.perform(post("/api/orders")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("[성공] 주문 취소 API 호출 시 200 OK를 반환해야 함")
+    void cancelOrderApiTest() throws Exception {
+        UUID orderId = UUID.randomUUID();
+        ResGetOrderDtoV1 response = ResGetOrderDtoV1.builder()
+                .orderId(orderId).status(OrderStatus.CANCELLED).build();
+        given(orderService.cancelOrder(orderId)).willReturn(response);
+
+        mockMvc.perform(patch("/api/orders/" + orderId + "/cancel"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("CANCELLED"));
+    }
+
+    @Test
+    @DisplayName("[성공] 주문 상태 변경 API 호출 시 변경된 상태가 반환되어야 함")
+    void updateOrderStatusApiTest() throws Exception {
+        UUID orderId = UUID.randomUUID();
+        ReqUpdateOrderStatusDtoV1 request = new ReqUpdateOrderStatusDtoV1(OrderStatus.ACCEPTED);
+        ResGetOrderDtoV1 response = ResGetOrderDtoV1.builder()
+                .orderId(orderId).status(OrderStatus.ACCEPTED).build();
+        
+        given(orderService.updateOrderStatus(any(), any())).willReturn(response);
+
+        mockMvc.perform(patch("/api/orders/" + orderId + "/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("ACCEPTED"));
+    }
+
+    @Test
+    @DisplayName("[성공] 주문 요청사항 수정(PUT) API가 정상 호출되어야 함")
+    void updateOrderRequestApiTest() throws Exception {
+        UUID orderId = UUID.randomUUID();
+        ReqUpdateOrderRequestDtoV1 updateRequest = ReqUpdateOrderRequestDtoV1.builder().request("수정내용").build();
+        ResGetOrderDtoV1 response = ResGetOrderDtoV1.builder().orderId(orderId).request("수정내용").build();
+        given(orderService.updateOrderRequest(any(), any())).willReturn(response);
+
+        mockMvc.perform(put("/api/orders/" + orderId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.request").value("수정내용"));
+    }
+
+    @Test
+    @DisplayName("[보안] 삭제된 주문 번호로 상세 조회 시 400 에러를 반환해야 함")
+    void getOrderDeletedFailureTest() throws Exception {
+        UUID orderId = UUID.randomUUID();
+        given(orderService.getOrder(orderId)).willThrow(new IllegalArgumentException("존재하지 않거나 삭제된 주문입니다."));
+
+        mockMvc.perform(get("/api/orders/" + orderId))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("BUSINESS_ERROR"));
+    }
+
+    @Test
+    @DisplayName("[실패] 잘못된 입력값(수량 0)으로 주문 생성 시 400 에러를 반환해야 함")
     void validationErrorTest() throws Exception {
-        // Given: 수량이 0인 잘못된 요청 데이터를 만듭니다.
         ReqCreateOrderDtoV1 invalidRequest = ReqCreateOrderDtoV1.builder()
-                .storeId(UUID.randomUUID())
-                .addressId(UUID.randomUUID())
-                .orderItems(List.of(
-                        ReqCreateOrderDtoV1.OrderItemRequest.builder()
-                                .menuId(UUID.randomUUID())
-                                .quantity(0) // 유효성 검사 위반
-                                .priceAtOrder(10000)
-                                .build()
-                ))
+                .storeId(UUID.randomUUID()).addressId(UUID.randomUUID())
+                .orderItems(List.of(ReqCreateOrderDtoV1.OrderItemRequest.builder().quantity(0).build()))
                 .build();
 
-        // When & Then
         mockMvc.perform(post("/api/orders")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(invalidRequest)))
-                .andDo(print()) // 콘솔에 상세 로그를 출력
+                .andDo(print())
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("VALIDATION_ERROR")) // code -> message 로 변경
-                .andExpect(jsonPath("$.errors[0].field").value("orderItems[0].quantity"))
-                .andExpect(jsonPath("$.errors[0].message").value("수량은 최소 1개 이상이어야 합니다.")); // reason -> message 로 변경
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
 
         verifyNoInteractions(orderService);
+    }
+
+    @Test
+    @DisplayName("[정책] 허용되지 않은 페이지 사이즈(100) 요청 시 기본값(10)으로 보정되어 정상 처리되어야 함")
+    void getOrdersSizeLimitTest() throws Exception {
+        given(orderService.getOrders(any(), any(), any())).willReturn(new PageImpl<>(List.of()));
+
+        mockMvc.perform(get("/api/orders?size=100"))
+                .andDo(print())
+                .andExpect(status().isOk());
     }
 }

--- a/src/test/java/com/example/whostolemyfood/order/OrderRepositoryTest.java
+++ b/src/test/java/com/example/whostolemyfood/order/OrderRepositoryTest.java
@@ -4,6 +4,7 @@ import com.example.whostolemyfood.global.config.JpaAuditingConfig;
 import com.example.whostolemyfood.order.domain.entity.OrderEntity;
 import com.example.whostolemyfood.order.domain.entity.OrderStatus;
 import com.example.whostolemyfood.order.domain.repository.OrderRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,12 +13,14 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
+@ActiveProfiles("test")
 @Import(JpaAuditingConfig.class)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class OrderRepositoryTest {
@@ -25,39 +28,98 @@ public class OrderRepositoryTest {
     @Autowired
     private OrderRepository orderRepository;
 
-    @Test
-    @DisplayName("주문 저장 및 조회 시 UUID PK와 상태값이 정확해야 함")
-    void saveAndFindOrderTest() {
-        OrderEntity order = createOrder(UUID.randomUUID());
-        OrderEntity savedOrder = orderRepository.save(order);
-
-        OrderEntity foundOrder = orderRepository.findById(savedOrder.getOrderId()).orElseThrow();
-        assertThat(foundOrder.getOrderId()).isNotNull();
-        assertThat(foundOrder.getStatus()).isEqualTo(OrderStatus.PENDING);
+    @BeforeEach
+    void setUp() {
+        // 실제 데이터베이스를 사용하므로 테스트 간의 독립성을 위해 데이터를 초기화합니다.
+        orderRepository.deleteAll();
     }
 
     @Test
-    @DisplayName("특정 가게의 주문만 필터링하여 조회할 수 있어야 함")
-    void findAllByStoreIdTest() {
+    @DisplayName("기본 페이징 조회 시 삭제되지 않은 주문만 조회되어야 함")
+    void findAllByIsDeletedFalseTest() {
+        // Given
+        OrderEntity activeOrder = orderRepository.save(createOrder(UUID.randomUUID()));
+        OrderEntity deletedOrder = orderRepository.save(createOrder(UUID.randomUUID()));
+        deletedOrder.markAsDeleted(UUID.randomUUID());
+        orderRepository.saveAndFlush(deletedOrder);
+
+        // When
+        Page<OrderEntity> result = orderRepository.findAllByIsDeletedFalse(PageRequest.of(0, 10));
+
+        // Then
+        assertThat(result.getTotalElements()).isEqualTo(1L);
+        assertThat(result.getContent().get(0).getOrderId()).isEqualTo(activeOrder.getOrderId());
+    }
+
+    @Test
+    @DisplayName("특정 가게의 활성 주문만 필터링하여 조회할 수 있어야 함")
+    void findAllByStoreIdAndIsDeletedFalseTest() {
+        // Given
         UUID storeA = UUID.randomUUID();
-        UUID storeB = UUID.randomUUID();
+        orderRepository.save(createOrder(storeA));
+        orderRepository.save(createOrder(storeA));
         
-        orderRepository.save(createOrder(storeA));
-        orderRepository.save(createOrder(storeA));
-        orderRepository.save(createOrder(storeB));
+        OrderEntity deletedOrder = orderRepository.save(createOrder(storeA));
+        deletedOrder.markAsDeleted(UUID.randomUUID());
+        orderRepository.saveAndFlush(deletedOrder);
 
-        Page<OrderEntity> orders = orderRepository.findAllByStoreId(storeA, PageRequest.of(0, 10));
-        assertThat(orders.getTotalElements()).isEqualTo(2);
+        // When
+        Page<OrderEntity> orders = orderRepository.findAllByStoreIdAndIsDeletedFalse(storeA, PageRequest.of(0, 10));
+
+        // Then
+        assertThat(orders.getTotalElements()).isEqualTo(2L);
     }
 
     @Test
-    @DisplayName("주문 삭제 시 물리 삭제가 아닌 Soft Delete(isDeleted=true)가 되어야 함")
+    @DisplayName("숨김 처리된 주문(isHidden=true)만 필터링하여 조회할 수 있어야 함")
+    void findAllByIsHiddenAndIsDeletedFalseTest() {
+        // Given
+        orderRepository.save(OrderEntity.builder()
+                .userId(UUID.randomUUID()).storeId(UUID.randomUUID()).addressId(UUID.randomUUID())
+                .totalPrice(10000).deliveryFee(3000).status(OrderStatus.PENDING).isHidden(true).build());
+        
+        orderRepository.save(OrderEntity.builder()
+                .userId(UUID.randomUUID()).storeId(UUID.randomUUID()).addressId(UUID.randomUUID())
+                .totalPrice(10000).deliveryFee(3000).status(OrderStatus.PENDING).isHidden(false).build());
+
+        // When
+        Page<OrderEntity> hiddenOrders = orderRepository.findAllByIsHiddenAndIsDeletedFalse(true, PageRequest.of(0, 10));
+
+        // Then
+        assertThat(hiddenOrders.getTotalElements()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("특정 가게의 주문 중 숨김 처리된 활성 주문만 필터링할 수 있어야 함")
+    void findAllByStoreIdAndIsHiddenAndIsDeletedFalseTest() {
+        // Given
+        UUID storeId = UUID.randomUUID();
+        orderRepository.save(OrderEntity.builder()
+                .userId(UUID.randomUUID()).storeId(storeId).addressId(UUID.randomUUID())
+                .totalPrice(10000).deliveryFee(3000).status(OrderStatus.PENDING).isHidden(true).build());
+        
+        orderRepository.save(OrderEntity.builder()
+                .userId(UUID.randomUUID()).storeId(storeId).addressId(UUID.randomUUID())
+                .totalPrice(10000).deliveryFee(3000).status(OrderStatus.PENDING).isHidden(false).build());
+
+        // When
+        Page<OrderEntity> result = orderRepository.findAllByStoreIdAndIsHiddenAndIsDeletedFalse(storeId, true, PageRequest.of(0, 10));
+
+        // Then
+        assertThat(result.getTotalElements()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("주문 삭제 시 Soft Delete(isDeleted=true)가 정상 작동해야 함")
     void softDeleteTest() {
+        // Given
         OrderEntity order = orderRepository.save(createOrder(UUID.randomUUID()));
         
+        // When
         order.markAsDeleted(UUID.randomUUID());
         orderRepository.saveAndFlush(order);
 
+        // Then
         OrderEntity foundOrder = orderRepository.findById(order.getOrderId()).orElseThrow();
         assertThat(foundOrder.getIsDeleted()).isTrue();
         assertThat(foundOrder.getDeletedAt()).isNotNull();
@@ -68,7 +130,7 @@ public class OrderRepositoryTest {
                 .userId(UUID.randomUUID())
                 .storeId(storeId)
                 .addressId(UUID.randomUUID())
-                .totalPrice(10000)
+                .totalPrice(13000)
                 .deliveryFee(3000)
                 .status(OrderStatus.PENDING)
                 .build();

--- a/src/test/java/com/example/whostolemyfood/order/OrderServiceTest.java
+++ b/src/test/java/com/example/whostolemyfood/order/OrderServiceTest.java
@@ -50,8 +50,8 @@ public class OrderServiceTest {
 
         ResCreateOrderDtoV1 response = orderService.createOrder(request);
 
-        // 20000*1 + 5000*2 = 30000
-        assertThat(response.getTotalPrice()).isEqualTo(30000);
+        // 20000*1 + 5000*2 + 3000(배달비) = 33000
+        assertThat(response.getTotalPrice()).isEqualTo(33000);
     }
 
     @Test

--- a/src/test/java/com/example/whostolemyfood/order/OrderServiceTest.java
+++ b/src/test/java/com/example/whostolemyfood/order/OrderServiceTest.java
@@ -7,12 +7,16 @@ import com.example.whostolemyfood.order.domain.repository.OrderRepository;
 import com.example.whostolemyfood.order.presentation.dto.request.ReqCreateOrderDtoV1;
 import com.example.whostolemyfood.order.presentation.dto.response.ResCreateOrderDtoV1;
 import com.example.whostolemyfood.order.presentation.dto.response.ResGetOrderDtoV1;
+import com.example.whostolemyfood.order.presentation.dto.response.ResGetOrderListDtoV1;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
@@ -34,54 +38,124 @@ public class OrderServiceTest {
     @Mock
     private OrderRepository orderRepository;
 
+    @Mock
+    private Object storeRepository; 
+    
+    @Mock
+    private Object addressRepository;
+
     @Test
-    @DisplayName("주문 생성 시 서버에서 상품별 총 결제 금액을 정확히 계산해야 함")
+    @DisplayName("[성공] 주문 생성 시 음식값과 배달비(3000원)가 정확히 합산되어야 함")
     void createOrderPriceCalculationTest() {
         ReqCreateOrderDtoV1 request = ReqCreateOrderDtoV1.builder()
-                .storeId(UUID.randomUUID())
-                .addressId(UUID.randomUUID())
-                .orderItems(List.of(
-                        ReqCreateOrderDtoV1.OrderItemRequest.builder().priceAtOrder(20000).quantity(1).build(),
-                        ReqCreateOrderDtoV1.OrderItemRequest.builder().priceAtOrder(5000).quantity(2).build()
-                ))
+                .storeId(UUID.randomUUID()).addressId(UUID.randomUUID())
+                .orderItems(List.of(ReqCreateOrderDtoV1.OrderItemRequest.builder().priceAtOrder(20000).quantity(1).build()))
                 .build();
-
-        given(orderRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+        
+        given(orderRepository.save(any())).willAnswer(invocation -> {
+            OrderEntity order = invocation.getArgument(0);
+            ReflectionTestUtils.setField(order, "orderId", UUID.randomUUID());
+            return order;
+        });
 
         ResCreateOrderDtoV1 response = orderService.createOrder(request);
-
-        // 20000*1 + 5000*2 + 3000(배달비) = 33000
-        assertThat(response.getTotalPrice()).isEqualTo(33000);
+        assertThat(response.getTotalPrice()).isEqualTo(23000);
+        assertThat(response.getOrderId()).isNotNull();
     }
 
     @Test
-    @DisplayName("주문 생성 후 5분이 경과하면 취소가 불가능해야 함 (IllegalStateException)")
+    @DisplayName("[성공] 5분 이내 취소 요청 시 주문 상태가 CANCELLED로 변경되어야 함")
+    void cancelOrderSuccessTest() {
+        UUID orderId = UUID.randomUUID();
+        OrderEntity order = OrderEntity.builder().orderId(orderId).status(OrderStatus.PENDING).isDeleted(false).build();
+        ReflectionTestUtils.setField(order, "createdAt", LocalDateTime.now().minusMinutes(2));
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+
+        ResGetOrderDtoV1 response = orderService.cancelOrder(orderId);
+        assertThat(response.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+    }
+
+    @Test
+    @DisplayName("[성공] 사장님이 주문 상태를 ACCEPTED로 변경할 수 있어야 함")
+    void updateOrderStatusSuccessTest() {
+        UUID orderId = UUID.randomUUID();
+        OrderEntity order = OrderEntity.builder().orderId(orderId).status(OrderStatus.PENDING).isDeleted(false).build();
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+
+        ResGetOrderDtoV1 response = orderService.updateOrderStatus(orderId, OrderStatus.ACCEPTED);
+        assertThat(response.getStatus()).isEqualTo(OrderStatus.ACCEPTED);
+    }
+
+    @Test
+    @DisplayName("[성공] 활성 상태인 주문은 상세 조회가 정상적으로 수행되어야 함")
+    void getOrderSuccessTest() {
+        UUID orderId = UUID.randomUUID();
+        OrderEntity order = OrderEntity.builder().orderId(orderId).totalPrice(23000).deliveryFee(3000).isDeleted(false).build();
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(order));
+
+        ResGetOrderDtoV1 response = orderService.getOrder(orderId);
+        assertThat(response.getOrderId()).isEqualTo(orderId);
+    }
+
+    @Test
+    @DisplayName("[성공] 주문 목록 조회 시 페이징 데이터가 정상적으로 반환되어야 함")
+    void getOrdersSuccessTest() {
+        OrderEntity order = OrderEntity.builder().orderId(UUID.randomUUID()).totalPrice(20000).isDeleted(false).build();
+        Page<OrderEntity> page = new PageImpl<>(List.of(order));
+        given(orderRepository.findAllByIsDeletedFalse(any())).willReturn(page);
+
+        Page<ResGetOrderListDtoV1> result = orderService.getOrders(null, null, PageRequest.of(0, 10));
+        assertThat(result.getTotalElements()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("[실패] 주문 생성 후 5분이 경과하면 취소가 불가능해야 함")
     void cancelOrderTimeLimitTest() {
         UUID orderId = UUID.randomUUID();
-        OrderEntity oldOrder = OrderEntity.builder()
-                .orderId(orderId)
-                .status(OrderStatus.PENDING)
-                .build();
-        
-        // 생성 시간을 6분 전으로 강제 설정
+        OrderEntity oldOrder = OrderEntity.builder().orderId(orderId).status(OrderStatus.PENDING).isDeleted(false).build();
         ReflectionTestUtils.setField(oldOrder, "createdAt", LocalDateTime.now().minusMinutes(6));
-        
         given(orderRepository.findById(orderId)).willReturn(Optional.of(oldOrder));
 
         assertThrows(IllegalStateException.class, () -> orderService.cancelOrder(orderId));
     }
 
     @Test
-    @DisplayName("수락된 주문(ACCEPTED)은 요청사항을 수정할 수 없어야 함 (도메인 보호 로직)")
-    void updateOrderRequestStatusCheckTest() {
+    @DisplayName("[실패] 이미 취소된(CANCELLED) 주문은 상태를 변경할 수 없어야 함")
+    void updateOrderStatusCancelledFailureTest() {
         UUID orderId = UUID.randomUUID();
-        OrderEntity acceptedOrder = OrderEntity.builder()
-                .orderId(orderId)
-                .status(OrderStatus.ACCEPTED)
-                .build();
+        OrderEntity cancelledOrder = OrderEntity.builder().orderId(orderId).status(OrderStatus.CANCELLED).isDeleted(false).build();
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(cancelledOrder));
 
+        assertThrows(IllegalStateException.class, () -> orderService.updateOrderStatus(orderId, OrderStatus.ACCEPTED));
+    }
+
+    @Test
+    @DisplayName("[실패] 이미 삭제된(isDeleted=true) 주문은 상세 조회가 불가능해야 함")
+    void getOrderDeletedFailureTest() {
+        UUID orderId = UUID.randomUUID();
+        OrderEntity deletedOrder = OrderEntity.builder().orderId(orderId).isDeleted(true).build();
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(deletedOrder));
+
+        assertThrows(IllegalArgumentException.class, () -> orderService.getOrder(orderId));
+    }
+
+    @Test
+    @DisplayName("[실패] 이미 수락(ACCEPTED)된 주문은 요청사항을 수정할 수 없어야 함")
+    void updateOrderRequestFailureTest() {
+        UUID orderId = UUID.randomUUID();
+        OrderEntity acceptedOrder = OrderEntity.builder().orderId(orderId).status(OrderStatus.ACCEPTED).isDeleted(false).build();
         given(orderRepository.findById(orderId)).willReturn(Optional.of(acceptedOrder));
 
-        assertThrows(IllegalStateException.class, () -> orderService.updateOrderRequest(orderId, "수정요청"));
+        assertThrows(IllegalStateException.class, () -> orderService.updateOrderRequest(orderId, "수정해주세요"));
+    }
+
+    @Test
+    @DisplayName("[실패] 배달 완료(DELIVERED)된 주문은 삭제할 수 없어야 함")
+    void deleteOrderDeliveredFailureTest() {
+        UUID orderId = UUID.randomUUID();
+        OrderEntity deliveredOrder = OrderEntity.builder().orderId(orderId).status(OrderStatus.DELIVERED).isDeleted(false).build();
+        given(orderRepository.findById(orderId)).willReturn(Optional.of(deliveredOrder));
+
+        assertThrows(IllegalStateException.class, () -> orderService.deleteOrder(orderId));
     }
 }


### PR DESCRIPTION
<br/>

## ✨  제목 : Refactor/#15 논리 삭제 데이터 노출 방지 및 주문 상태 변경 방어 로직 강화


<br/>

## 🔨 작업 내용

- 조회 시 삭제된 데이터(isDeleted=true)가 포함되지 않도록 필터링 로직 보강
- 취소 또는 배달 완료된 주문의 무분별한 상태 변경을 차단하는 방어 로직 추가
- totalPrice에 배달비가 합산되도록 로직 수정
- 비즈니스 예외 상황 및 보안 취약점 검증을 위한 테스트 케이스 추가 검증
  
<br/>

## 🍻  실행된 화면(postman에서 테스트한 것 캡쳐해서 올려주세요 성공, 예외처리되는것까지)

- ① 주문 생성 (POST)
<img width="1533" height="1194" alt="image" src="https://github.com/user-attachments/assets/c8057700-495b-4442-b291-18ded6799765" />
- ② 주문 상세 조회 (GET)
<img width="1544" height="1063" alt="image" src="https://github.com/user-attachments/assets/5ea79a66-1841-4ce4-868f-74769e7d39d2" />
- ③ 주문 목록 조회 (GET - 삭제된 데이터 필터링)
<img width="1520" height="1487" alt="image" src="https://github.com/user-attachments/assets/cf20a3c5-d842-4ddd-92fc-237b88959aa6" />
- ④ 주문 상태 변경 (PATCH)
<img width="1535" height="1185" alt="image" src="https://github.com/user-attachments/assets/5a6e66e5-3ebc-447f-9399-a0304750dc19" />
- ⑤ 주문 요청사항 수정 시도 (PUT - 방어 로직)
<img width="1511" height="734" alt="image" src="https://github.com/user-attachments/assets/77982c08-af35-487e-ae28-84fed65a5019" />
- ⑥ 주문 삭제 (DELETE - Soft Delete)
<img width="1549" height="572" alt="image" src="https://github.com/user-attachments/assets/a0b5297d-e53f-4403-8982-75663baa44db" />
- ⑦ 삭제된 주문 조회 시도 (GET - 보안 체크)
<img width="1470" height="726" alt="image" src="https://github.com/user-attachments/assets/458af20d-5174-49e5-8f55-1d74b660b1ed" />


<br/>

## 🔎   앞으로의 과제

- 인증 연동: 서비스(OrderServiceV1)의 mockUserId를 SecurityContext에서 추출한 실제 유저 UUID로 교체하기
- 권한 필터링: 리포지토리 조회 시 로그인 유저의 권한(고객/사장님)에 따라 본인 데이터만 나오도록 필터링 로직 추가


  <br/>

