### PR TITLE
[Feat] #60 Order/Address 매 요청 시 DB 권한 재검증 및 테스트 코드 검증 완료 

### DIFF
--- a/src/main/java/com/example/whostolemyfood/address/application/service/AddressServiceV1.java
+++ b/src/main/java/com/example/whostolemyfood/address/application/service/AddressServiceV1.java
@@ -8,6 +8,9 @@ import com.example.whostolemyfood.address.presentation.dto.response.ResCreateAdd
 import com.example.whostolemyfood.address.presentation.dto.response.ResGetAddressDtoV1;
 import com.example.whostolemyfood.global.exception.CustomException;
 import com.example.whostolemyfood.global.exception.ErrorCode;
+import com.example.whostolemyfood.user.domain.entity.UserEntity;
+import com.example.whostolemyfood.user.domain.entity.UserRole;
+import com.example.whostolemyfood.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -24,12 +27,32 @@ import java.util.UUID;
 public class AddressServiceV1 {
 
     private final AddressRepository addressRepository;
+    private final UserRepository userRepository; // (1) DB 재검증을 위해 유저 레포지토리 주입
+
+    /**
+     * 매 요청 시 DB 권한 실시간 재검증
+     */
+    private void validateUserRoleFromDB(UUID userId, UserRole tokenRole) {
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getIsDeleted()) {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        if (user.getUserRole() != tokenRole) {
+            log.warn("[Security] Role mismatch for User: {}. Token: {}, DB: {}", userId, tokenRole, user.getUserRole());
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+    }
 
     /**
      * 배송지 생성
      */
     @Transactional
-    public ResCreateAddressDtoV1 createAddress(ReqCreateAddressDtoV1 request, UUID userId) {
+    public ResCreateAddressDtoV1 createAddress(ReqCreateAddressDtoV1 request, UUID userId, UserRole role) {
+        validateUserRoleFromDB(userId, role); // DB 권한 재검증 실행
+
         log.info("[Address] Creating new address for User: {}, Alias: {}", userId, request.getAlias());
         
         if (Boolean.TRUE.equals(request.getIsDefault())) {
@@ -37,20 +60,19 @@ public class AddressServiceV1 {
         }
 
         AddressEntity address = request.toEntity(userId);
-        
-        // 🚨 [Audit 필수사항] 생성자 정보 기록
         address.markCreatedBy(userId);
 
         AddressEntity savedAddress = addressRepository.save(address);
         
-        log.info("[Address] Address created successfully. AddressId: {}, User: {}", savedAddress.getId(), userId);
         return ResCreateAddressDtoV1.from(savedAddress, "배송지가 성공적으로 생성되었습니다.");
     }
 
     /**
      * 본인의 배송지 목록 조회
      */
-    public Page<ResGetAddressDtoV1> getMyAddresses(UUID userId, String alias, Pageable pageable) {
+    public Page<ResGetAddressDtoV1> getMyAddresses(UUID userId, UserRole role, String alias, Pageable pageable) {
+        validateUserRoleFromDB(userId, role); // DB 권한 재검증 실행
+
         log.info("[Address] Fetching addresses for User: {}, Filter: {}", userId, alias);
         
         Page<AddressEntity> addresses;
@@ -60,7 +82,6 @@ public class AddressServiceV1 {
             addresses = addressRepository.findAllByUserIdAndIsDeletedFalse(userId, pageable);
         }
         
-        log.info("[Address] Successfully fetched {} addresses for User: {}", addresses.getTotalElements(), userId);
         return addresses.map(ResGetAddressDtoV1::from);
     }
 
@@ -68,18 +89,14 @@ public class AddressServiceV1 {
      * 배송지 수정
      */
     @Transactional
-    public ResGetAddressDtoV1 updateAddress(UUID addressId, ReqUpdateAddressDtoV1 request, UUID userId) {
-        log.info("[Address] Updating address info. AddressId: {}, User: {}", addressId, userId);
-        
+    public ResGetAddressDtoV1 updateAddress(UUID addressId, ReqUpdateAddressDtoV1 request, UUID userId, UserRole role) {
+        validateUserRoleFromDB(userId, role); // DB 권한 재검증 실행
+
         AddressEntity address = addressRepository.findByIdAndIsDeletedFalse(addressId)
-                .orElseThrow(() -> {
-                    log.warn("[Address] Update failed. Address not found. AddressId: {}", addressId);
-                    return new CustomException(ErrorCode.ADDRESS_NOT_FOUND);
-                });
+                .orElseThrow(() -> new CustomException(ErrorCode.ADDRESS_NOT_FOUND));
 
         // [인가] 본인 확인 로직
         if (!address.getUserId().equals(userId)) {
-            log.warn("[Address] Update unauthorized. User {} tried to update address owned by {}", userId, address.getUserId());
             throw new CustomException(ErrorCode.ADDRESS_NOT_OWNER);
         }
 
@@ -95,10 +112,8 @@ public class AddressServiceV1 {
                 request.getIsDefault()
         );
         
-        // 🚨 [Audit 필수사항] 수정자 정보 기록
         address.markUpdatedBy(userId);
 
-        log.info("[Address] Address updated successfully. AddressId: {}", addressId);
         return ResGetAddressDtoV1.from(address, "배송지 정보가 성공적으로 수정되었습니다.");
     }
 
@@ -106,31 +121,22 @@ public class AddressServiceV1 {
      * 배송지 삭제 (Soft Delete)
      */
     @Transactional
-    public void deleteAddress(UUID addressId, UUID userId) {
-        log.info("[Address] Requesting soft-delete. AddressId: {}, User: {}", addressId, userId);
-        
+    public void deleteAddress(UUID addressId, UUID userId, UserRole role) {
+        validateUserRoleFromDB(userId, role); // DB 권한 재검증 실행
+
         AddressEntity address = addressRepository.findByIdAndIsDeletedFalse(addressId)
-                .orElseThrow(() -> {
-                    log.warn("[Address] Delete failed. Address not found. AddressId: {}", addressId);
-                    return new CustomException(ErrorCode.ADDRESS_NOT_FOUND);
-                });
+                .orElseThrow(() -> new CustomException(ErrorCode.ADDRESS_NOT_FOUND));
 
         // [인가] 본인 확인 로직
         if (!address.getUserId().equals(userId)) {
-            log.warn("[Address] Delete unauthorized. User {} tried to delete address owned by {}", userId, address.getUserId());
             throw new CustomException(ErrorCode.ADDRESS_NOT_OWNER);
         }
 
-        // [Audit 필수사항] 삭제자 정보 기록 및 Soft Delete 수행
         address.softDelete(userId);
-        log.info("[Address] Address soft-deleted successfully. AddressId: {}", addressId);
     }
 
     private void handleDefaultAddress(UUID userId) {
         addressRepository.findByUserIdAndIsDefaultTrueAndIsDeletedFalse(userId)
-                .ifPresent(existingDefault -> {
-                    log.info("[Address] Unsetting existing default address. AddressId: {}, User: {}", existingDefault.getId(), userId);
-                    existingDefault.setDefault(false);
-                });
+                .ifPresent(existingDefault -> existingDefault.setDefault(false));
     }
 }

--- a/src/main/java/com/example/whostolemyfood/address/domain/repository/AddressRepository.java
+++ b/src/main/java/com/example/whostolemyfood/address/domain/repository/AddressRepository.java
@@ -4,17 +4,18 @@ import com.example.whostolemyfood.address.domain.entity.AddressEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 import java.util.UUID;
 
 public interface AddressRepository extends JpaRepository<AddressEntity, UUID> {
     
-    Page<AddressEntity> findAllByUserIdAndAliasContainingAndIsDeletedFalse(UUID userId, String alias, Pageable pageable);
+    Page<AddressEntity> findAllByUserIdAndAliasContainingAndIsDeletedFalse(@Param("userId") UUID userId, @Param("alias") String alias, @Param("pageable") Pageable pageable);
 
-    Page<AddressEntity> findAllByUserIdAndIsDeletedFalse(UUID userId, Pageable pageable);
+    Page<AddressEntity> findAllByUserIdAndIsDeletedFalse(@Param("userId") UUID userId, @Param("pageable") Pageable pageable);
 
-    Optional<AddressEntity> findByIdAndIsDeletedFalse(UUID id);
+    Optional<AddressEntity> findByIdAndIsDeletedFalse(@Param("id") UUID id);
 
-    Optional<AddressEntity> findByUserIdAndIsDefaultTrueAndIsDeletedFalse(UUID userId);
+    Optional<AddressEntity> findByUserIdAndIsDefaultTrueAndIsDeletedFalse(@Param("userId") UUID userId);
 }

--- a/src/main/java/com/example/whostolemyfood/address/domain/repository/AddressRepository.java
+++ b/src/main/java/com/example/whostolemyfood/address/domain/repository/AddressRepository.java
@@ -11,9 +11,9 @@ import java.util.UUID;
 
 public interface AddressRepository extends JpaRepository<AddressEntity, UUID> {
     
-    Page<AddressEntity> findAllByUserIdAndAliasContainingAndIsDeletedFalse(@Param("userId") UUID userId, @Param("alias") String alias, @Param("pageable") Pageable pageable);
+    Page<AddressEntity> findAllByUserIdAndAliasContainingAndIsDeletedFalse(@Param("userId") UUID userId, @Param("alias") String alias, Pageable pageable);
 
-    Page<AddressEntity> findAllByUserIdAndIsDeletedFalse(@Param("userId") UUID userId, @Param("pageable") Pageable pageable);
+    Page<AddressEntity> findAllByUserIdAndIsDeletedFalse(@Param("userId") UUID userId, Pageable pageable);
 
     Optional<AddressEntity> findByIdAndIsDeletedFalse(@Param("id") UUID id);
 

--- a/src/main/java/com/example/whostolemyfood/address/presentation/controller/AddressControllerV1.java
+++ b/src/main/java/com/example/whostolemyfood/address/presentation/controller/AddressControllerV1.java
@@ -17,6 +17,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -34,41 +35,44 @@ public class AddressControllerV1 {
 
     @Operation(summary = "배송지 생성", description = "로그인한 사용자의 새로운 배송지를 생성합니다.")
     @PostMapping
+    @PreAuthorize("hasAnyRole('CUSTOMER')")
     public ResponseEntity<ResCreateAddressDtoV1> createAddress(
             @Valid @RequestBody ReqCreateAddressDtoV1 request,
             @AuthenticationPrincipal AuthUser authUser) {
-        return ResponseEntity.ok(addressService.createAddress(request, authUser.userId()));
+        return ResponseEntity.ok(addressService.createAddress(request, authUser.userId(), authUser.role()));
     }
 
     @Operation(summary = "본인 배송지 목록 조회", description = "로그인한 사용자의 배송지 목록을 조회합니다. 별칭으로 검색이 가능합니다.")
     @GetMapping
+    @PreAuthorize("hasAnyRole('CUSTOMER')")
     public ResponseEntity<PageResponse<ResGetAddressDtoV1>> getMyAddresses(
             @RequestParam(name = "alias", required = false) String alias,
             @AuthenticationPrincipal AuthUser authUser,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         
         Pageable validatedPageable = PageUtil.validatePageSize(pageable);
-        Page<ResGetAddressDtoV1> addresses = addressService.getMyAddresses(authUser.userId(), alias, validatedPageable);
+        Page<ResGetAddressDtoV1> addresses = addressService.getMyAddresses(authUser.userId(), authUser.role(), alias, validatedPageable);
         
-        // 🚨 SA 문서 규격에 맞는 PageResponse로 감싸서 반환
         return ResponseEntity.ok(new PageResponse<>(addresses));
     }
 
     @Operation(summary = "배송지 수정", description = "특정 배송지의 정보를 수정합니다. 본인의 배송지만 수정 가능합니다.")
     @PutMapping("/{addressId}")
+    @PreAuthorize("hasAnyRole('CUSTOMER')")
     public ResponseEntity<ResGetAddressDtoV1> updateAddress(
             @PathVariable("addressId") UUID addressId,
             @Valid @RequestBody ReqUpdateAddressDtoV1 request,
             @AuthenticationPrincipal AuthUser authUser) {
-        return ResponseEntity.ok(addressService.updateAddress(addressId, request, authUser.userId()));
+        return ResponseEntity.ok(addressService.updateAddress(addressId, request, authUser.userId(), authUser.role()));
     }
 
     @Operation(summary = "배송지 삭제", description = "특정 배송지를 삭제(Soft Delete) 처리합니다. 본인의 배송지만 삭제 가능합니다.")
     @DeleteMapping("/{addressId}")
+    @PreAuthorize("hasAnyRole('CUSTOMER')")
     public ResponseEntity<Void> deleteAddress(
             @PathVariable("addressId") UUID addressId,
             @AuthenticationPrincipal AuthUser authUser) {
-        addressService.deleteAddress(addressId, authUser.userId());
+        addressService.deleteAddress(addressId, authUser.userId(), authUser.role());
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/example/whostolemyfood/order/application/service/OrderServiceV1.java
+++ b/src/main/java/com/example/whostolemyfood/order/application/service/OrderServiceV1.java
@@ -17,7 +17,9 @@ import com.example.whostolemyfood.order.presentation.dto.response.ResGetOrderLis
 import com.example.whostolemyfood.store.domain.entity.StoreEntity;
 import com.example.whostolemyfood.store.domain.entity.StoreStatus;
 import com.example.whostolemyfood.store.domain.repository.StoreRepository;
+import com.example.whostolemyfood.user.domain.entity.UserEntity;
 import com.example.whostolemyfood.user.domain.entity.UserRole;
+import com.example.whostolemyfood.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -41,15 +43,31 @@ public class OrderServiceV1 {
     private final StoreRepository storeRepository;
     private final MenuRepository menuRepository;
     private final AddressRepository addressRepository;
+    private final UserRepository userRepository; // (1) DB 재검증을 위해 유저 레포지토리 주입
+
+    // 매 요청 시 DB 권한 재검증
+    private void validateUserRoleFromDB(UUID userId, UserRole tokenRole) {
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getIsDeleted()) {
+            log.warn("[Security] Deleted user access attempt. User: {}", userId);
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        if (user.getUserRole() != tokenRole) {
+            log.warn("[Security] Role mismatch detected! User: {}, TokenRole: {}, DBRole: {}", 
+                     userId, tokenRole, user.getUserRole());
+            throw new CustomException(ErrorCode.ACCESS_DENIED); // 실시간 권한 변경 시 차단
+        }
+    }
 
     /**
      * 주문 생성 (CUSTOMER 전용)
      */
     @Transactional
     public ResCreateOrderDtoV1 createOrder(ReqCreateOrderDtoV1 request, UUID userId, UserRole role) {
-        if (role != UserRole.CUSTOMER) {
-            throw new CustomException(ErrorCode.ACCESS_DENIED);
-        }
+        validateUserRoleFromDB(userId, role); // DB 권한 재검증 실행
 
         log.info("[Order] Creating order. User: {}, Store: {}", userId, request.getStoreId());
 
@@ -126,6 +144,8 @@ public class OrderServiceV1 {
      * 주문 상세 조회
      */
     public ResGetOrderDtoV1 getOrder(UUID orderId, UUID userId, UserRole role) {
+        validateUserRoleFromDB(userId, role); // DB 권한 재검증 실행
+
         OrderEntity order = orderRepository.findById(orderId)
                 .filter(o -> !o.getIsDeleted())
                 .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
@@ -154,6 +174,8 @@ public class OrderServiceV1 {
      * 주문 목록 조회
      */
     public Page<ResGetOrderListDtoV1> getOrders(UUID storeId, Boolean isHidden, Pageable pageable, UUID userId, UserRole role) {
+        validateUserRoleFromDB(userId, role); // DB 권한 재검증 실행
+
         if (role == UserRole.CUSTOMER) {
             return orderRepository.findAllByUserIdAndIsDeletedFalse(userId, pageable).map(ResGetOrderListDtoV1::from);
         }
@@ -183,6 +205,8 @@ public class OrderServiceV1 {
      */
     @Transactional
     public ResGetOrderDtoV1 cancelOrder(UUID orderId, UUID userId, UserRole role) {
+        validateUserRoleFromDB(userId, role); // DB 권한 재검증 실행
+
         OrderEntity order = orderRepository.findById(orderId)
                 .filter(o -> !o.getIsDeleted())
                 .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
@@ -215,9 +239,7 @@ public class OrderServiceV1 {
      */
     @Transactional
     public ResGetOrderDtoV1 updateOrderRequest(UUID orderId, String newRequest, UUID userId, UserRole role) {
-        if (role != UserRole.CUSTOMER) {
-            throw new CustomException(ErrorCode.ACCESS_DENIED);
-        }
+        validateUserRoleFromDB(userId, role); // DB 권한 재검증 실행
 
         OrderEntity order = orderRepository.findById(orderId)
                 .filter(o -> !o.getIsDeleted())
@@ -242,6 +264,8 @@ public class OrderServiceV1 {
      */
     @Transactional
     public ResGetOrderDtoV1 updateOrderStatus(UUID orderId, OrderStatus nextStatus, UUID userId, UserRole role) {
+        validateUserRoleFromDB(userId, role); // DB 권한 재검증 실행
+
         OrderEntity order = orderRepository.findById(orderId)
                 .filter(o -> !o.getIsDeleted())
                 .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
@@ -252,16 +276,13 @@ public class OrderServiceV1 {
             if (store.getUser() == null || !store.getUser().getId().equals(userId)) {
                 throw new CustomException(ErrorCode.ORDER_FORBIDDEN_FOR_OWNER);
             }
-        } else if (role == UserRole.CUSTOMER) {
-            throw new CustomException(ErrorCode.ACCESS_DENIED);
         }
 
         try {
-            // 🚨 리플렉션 대신 엔티티의 전용 메서드 호출
             if (role == UserRole.MASTER || role == UserRole.MANAGER) {
-                order.forceUpdateStatus(nextStatus); // 관리자는 슈퍼 권한으로 강제 변경
+                order.forceUpdateStatus(nextStatus); 
             } else {
-                order.updateStatus(nextStatus); // 사장님은 정해진 순서 엄수
+                order.updateStatus(nextStatus); 
             }
             order.markUpdatedBy(userId);
         } catch (IllegalStateException e) {
@@ -276,9 +297,7 @@ public class OrderServiceV1 {
      */
     @Transactional
     public void deleteOrder(UUID orderId, UUID userId, UserRole role) {
-        if (role != UserRole.MASTER) {
-            throw new CustomException(ErrorCode.ACCESS_DENIED);
-        }
+        validateUserRoleFromDB(userId, role); // DB 권한 재검증 실행
 
         OrderEntity order = orderRepository.findById(orderId)
                 .filter(o -> !o.getIsDeleted())

--- a/src/main/java/com/example/whostolemyfood/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/example/whostolemyfood/order/domain/repository/OrderRepository.java
@@ -14,29 +14,29 @@ public interface OrderRepository extends JpaRepository<OrderEntity, UUID> {
     /**
      * 기본 페이징 조회 (삭제된 데이터 제외)
      */
-    Page<OrderEntity> findAllByIsDeletedFalse(@Param("pageable") Pageable pageable);
+    Page<OrderEntity> findAllByIsDeletedFalse(Pageable pageable);
 
     /**
      * 특정 가게의 활성 주문 목록 조회
      */
-    Page<OrderEntity> findAllByStoreIdAndIsDeletedFalse(@Param("storeId") UUID storeId, @Param("pageable") Pageable pageable);
+    Page<OrderEntity> findAllByStoreIdAndIsDeletedFalse(@Param("storeId") UUID storeId, Pageable pageable);
 
     /**
      * 가게 ID 및 숨김 여부에 따른 필터링 조회 (삭제된 데이터 제외)
      */
-    Page<OrderEntity> findAllByStoreIdAndIsHiddenAndIsDeletedFalse(@Param("storeId") UUID storeId, @Param("isHidden") Boolean isHidden, @Param("pageable") Pageable pageable);
+    Page<OrderEntity> findAllByStoreIdAndIsHiddenAndIsDeletedFalse(@Param("storeId") UUID storeId, @Param("isHidden") Boolean isHidden, Pageable pageable);
 
     /**
      * 전체 주문 중 숨김 여부에 따른 필터링 조회 (삭제된 데이터 제외)
      */
-    Page<OrderEntity> findAllByIsHidden(@Param("isHidden") Boolean isHidden, @Param("pageable") Pageable pageable);
+    Page<OrderEntity> findAllByIsHidden(@Param("isHidden") Boolean isHidden, Pageable pageable);
 
     /**
      * 결제를 위한 주문 존재 여부 조회
      */
     Optional<OrderEntity> findByOrderIdAndUserId(@Param("orderId") UUID orderId, @Param("userId") UUID userId);
 
-    Page<OrderEntity> findAllByIsHiddenAndIsDeletedFalse(@Param("isHidden") Boolean isHidden, @Param("pageable") Pageable pageable);
+    Page<OrderEntity> findAllByIsHiddenAndIsDeletedFalse(@Param("isHidden") Boolean isHidden, Pageable pageable);
 
     /**
      * Soft Delete가 false인지 검사
@@ -44,5 +44,5 @@ public interface OrderRepository extends JpaRepository<OrderEntity, UUID> {
     Optional<OrderEntity> findByOrderIdAndIsDeletedFalse(@Param("orderId") UUID orderId);
 
     // [RBAC] CUSTOMER: 본인의 주문만 조회
-    Page<OrderEntity> findAllByUserIdAndIsDeletedFalse(@Param("userId") UUID userId, @Param("pageable") Pageable pageable);
+    Page<OrderEntity> findAllByUserIdAndIsDeletedFalse(@Param("userId") UUID userId, Pageable pageable);
 }

--- a/src/main/java/com/example/whostolemyfood/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/example/whostolemyfood/order/domain/repository/OrderRepository.java
@@ -4,50 +4,45 @@ import com.example.whostolemyfood.order.domain.entity.OrderEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 import java.util.UUID;
 
-/**
- * [Repository] 주문(Order) 도메인 전용 리포지토리 인터페이스
- * - 실무 표준에 따라 모든 조회 시 논리 삭제(isDeleted = false)된 데이터만 필터링합니다.
- */
 public interface OrderRepository extends JpaRepository<OrderEntity, UUID> {
     
     /**
      * 기본 페이징 조회 (삭제된 데이터 제외)
      */
-    Page<OrderEntity> findAllByIsDeletedFalse(Pageable pageable);
+    Page<OrderEntity> findAllByIsDeletedFalse(@Param("pageable") Pageable pageable);
 
     /**
      * 특정 가게의 활성 주문 목록 조회
      */
-    Page<OrderEntity> findAllByStoreIdAndIsDeletedFalse(UUID storeId, Pageable pageable);
+    Page<OrderEntity> findAllByStoreIdAndIsDeletedFalse(@Param("storeId") UUID storeId, @Param("pageable") Pageable pageable);
 
     /**
      * 가게 ID 및 숨김 여부에 따른 필터링 조회 (삭제된 데이터 제외)
      */
-    Page<OrderEntity> findAllByStoreIdAndIsHiddenAndIsDeletedFalse(UUID storeId, Boolean isHidden, Pageable pageable);
+    Page<OrderEntity> findAllByStoreIdAndIsHiddenAndIsDeletedFalse(@Param("storeId") UUID storeId, @Param("isHidden") Boolean isHidden, @Param("pageable") Pageable pageable);
 
     /**
      * 전체 주문 중 숨김 여부에 따른 필터링 조회 (삭제된 데이터 제외)
      */
-    Page<OrderEntity> findAllByIsHidden(Boolean isHidden, Pageable pageable);
+    Page<OrderEntity> findAllByIsHidden(@Param("isHidden") Boolean isHidden, @Param("pageable") Pageable pageable);
 
     /**
      * 결제를 위한 주문 존재 여부 조회
      */
-    Optional<OrderEntity> findByOrderIdAndUserId(UUID orderId, UUID userId);
+    Optional<OrderEntity> findByOrderIdAndUserId(@Param("orderId") UUID orderId, @Param("userId") UUID userId);
 
-    Page<OrderEntity> findAllByIsHiddenAndIsDeletedFalse(Boolean isHidden, Pageable pageable);
+    Page<OrderEntity> findAllByIsHiddenAndIsDeletedFalse(@Param("isHidden") Boolean isHidden, @Param("pageable") Pageable pageable);
 
     /**
      * Soft Delete가 false인지 검사
      */
-    Optional<OrderEntity> findByOrderIdAndIsDeletedFalse(UUID orderId);
+    Optional<OrderEntity> findByOrderIdAndIsDeletedFalse(@Param("orderId") UUID orderId);
 
     // [RBAC] CUSTOMER: 본인의 주문만 조회
-    Page<OrderEntity> findAllByUserIdAndIsDeletedFalse(UUID userId, Pageable pageable);
+    Page<OrderEntity> findAllByUserIdAndIsDeletedFalse(@Param("userId") UUID userId, @Param("pageable") Pageable pageable);
 }
-
-

--- a/src/main/java/com/example/whostolemyfood/order/presentation/controller/OrderControllerV1.java
+++ b/src/main/java/com/example/whostolemyfood/order/presentation/controller/OrderControllerV1.java
@@ -19,6 +19,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -39,6 +40,7 @@ public class OrderControllerV1 {
      */
     @Operation(summary = "주문 생성", description = "새로운 주문을 생성합니다. (CUSTOMER 전용)")
     @PostMapping
+    @PreAuthorize("hasAnyRole('CUSTOMER')")
     public ResponseEntity<ResCreateOrderDtoV1> createOrder(
             @Valid @RequestBody ReqCreateOrderDtoV1 request,
             @AuthenticationPrincipal AuthUser authUser) {
@@ -50,6 +52,7 @@ public class OrderControllerV1 {
      */
     @Operation(summary = "주문 상세 조회", description = "본인의 주문 또는 내 가게 주문, 관리자 권한으로 조회합니다.")
     @GetMapping("/{orderId}")
+    @PreAuthorize("hasAnyRole('CUSTOMER', 'OWNER', 'MANAGER', 'MASTER')")
     public ResponseEntity<ResGetOrderDtoV1> getOrder(
             @PathVariable("orderId") UUID orderId,
             @AuthenticationPrincipal AuthUser authUser) {
@@ -61,6 +64,7 @@ public class OrderControllerV1 {
      */
     @Operation(summary = "주문 목록 조회 및 검색", description = "권한에 따라 접근 가능한 주문 목록을 필터링하여 조회합니다.")
     @GetMapping
+    @PreAuthorize("hasAnyRole('CUSTOMER', 'OWNER', 'MANAGER', 'MASTER')")
     public ResponseEntity<PageResponse<ResGetOrderListDtoV1>> getOrders(
             @RequestParam(name = "storeId", required = false) UUID storeId,
             @RequestParam(name = "isHidden", required = false) Boolean isHidden,
@@ -74,10 +78,11 @@ public class OrderControllerV1 {
     }
 
     /**
-     * 주문 수정(요청사항 수정) API (CUSTOMER 전용)
+     * 주문 요청사항 수정 API (CUSTOMER 전용)
      */
     @Operation(summary = "주문 요청사항 수정", description = "본인의 주문 중 수락 전(PENDING) 상태에서만 수정 가능합니다.")
     @PutMapping("/{orderId}")
+    @PreAuthorize("hasAnyRole('CUSTOMER')")
     public ResponseEntity<ResGetOrderDtoV1> updateOrderRequest(
             @PathVariable("orderId") UUID orderId, 
             @Valid @RequestBody ReqUpdateOrderRequestDtoV1 requestDto,
@@ -90,6 +95,7 @@ public class OrderControllerV1 {
      */
     @Operation(summary = "주문 취소", description = "본인의 주문(5분 이내) 또는 MASTER 권한으로 취소 가능합니다.")
     @PatchMapping("/{orderId}/cancel")
+    @PreAuthorize("hasAnyRole('CUSTOMER', 'MASTER')")
     public ResponseEntity<ResGetOrderDtoV1> cancelOrder(
             @PathVariable("orderId") UUID orderId,
             @AuthenticationPrincipal AuthUser authUser) {
@@ -101,6 +107,7 @@ public class OrderControllerV1 {
      */
     @Operation(summary = "주문 상태 변경", description = "가게 사장님(내 가게 한정) 또는 관리자만 상태를 단계별로 변경할 수 있습니다.")
     @PatchMapping("/{orderId}/status")
+    @PreAuthorize("hasAnyRole('OWNER', 'MANAGER', 'MASTER')")
     public ResponseEntity<ResGetOrderDtoV1> updateOrderStatus(
             @PathVariable("orderId") UUID orderId,
             @Valid @RequestBody ReqUpdateOrderStatusDtoV1 request,
@@ -113,6 +120,7 @@ public class OrderControllerV1 {
      */
     @Operation(summary = "주문 삭제", description = "오직 MASTER 권한으로만 주문 내역을 Soft Delete 처리합니다.")
     @DeleteMapping("/{orderId}")
+    @PreAuthorize("hasAnyRole('MASTER')")
     public ResponseEntity<Void> deleteOrder(
             @PathVariable("orderId") UUID orderId,
             @AuthenticationPrincipal AuthUser authUser) {

--- a/src/test/java/com/example/whostolemyfood/address/AddressControllerTest.java
+++ b/src/test/java/com/example/whostolemyfood/address/AddressControllerTest.java
@@ -25,6 +25,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
 import java.util.List;
 import java.util.UUID;
@@ -54,86 +55,129 @@ public class AddressControllerTest {
     @MockitoBean
     private JwtUtil jwtUtil;
 
-    private AuthUser authUser;
+    private AuthUser customerUser;
+    private AuthUser ownerUser;
     private UUID userId;
 
     @BeforeEach
     void setUp() {
         userId = UUID.randomUUID();
-        authUser = new AuthUser(userId, "test@example.com", UserRole.CUSTOMER);
+        customerUser = new AuthUser(userId, "customer@example.com", UserRole.CUSTOMER);
+        ownerUser = new AuthUser(UUID.randomUUID(), "owner@example.com", UserRole.OWNER);
     }
 
     @Test
     @DisplayName("[성공] 배송지 생성 API - 200 OK")
-    void createAddressApiTest() throws Exception {
+    void createAddress_Authorized() throws Exception {
         ReqCreateAddressDtoV1 request = ReqCreateAddressDtoV1.builder()
-                .alias("집").address("서울특별시 종로구").detail("101호").zipCode("12345").isDefault(true)
+                .alias("우리집").address("서울특별시 종로구").detail("101호").zipCode("12345").isDefault(true)
                 .build();
         ResCreateAddressDtoV1 response = ResCreateAddressDtoV1.builder().addressId(UUID.randomUUID()).build();
         
-        given(addressService.createAddress(any(), eq(userId))).willReturn(response);
+        given(addressService.createAddress(any(), eq(userId), eq(UserRole.CUSTOMER))).willReturn(response);
 
         mockMvc.perform(post("/api/v1/addresses")
-                        .with(user(authUser))
+                        .with(user(customerUser))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
+                .andDo(MockMvcResultHandlers.print()) // 로깅 추가
                 .andExpect(status().isOk());
     }
 
     @Test
     @DisplayName("[성공] 본인 배송지 목록 조회 API - 200 OK")
-    void getMyAddressesApiTest() throws Exception {
-        given(addressService.getMyAddresses(eq(userId), any(), any())).willReturn(new PageImpl<>(List.of()));
+    void getMyAddresses_Authorized() throws Exception {
+        given(addressService.getMyAddresses(eq(userId), eq(UserRole.CUSTOMER), any(), any()))
+                .willReturn(new PageImpl<>(List.of()));
 
-        mockMvc.perform(get("/api/v1/addresses?size=10")
-                        .with(user(authUser)))
+        mockMvc.perform(get("/api/v1/addresses")
+                        .with(user(customerUser)))
+                .andDo(MockMvcResultHandlers.print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.content").isArray()); // PageResponse 구조에 맞춰 수정
+                .andExpect(jsonPath("$.content").isArray());
     }
 
     @Test
-    @DisplayName("[성공] 배송지 수정 API - 200 OK")
-    void updateAddressApiTest() throws Exception {
+    @DisplayName("[인가 실패] 타인의 배송지 수정 시도 - 403 Forbidden")
+    void updateAddress_NotOwner() throws Exception {
         UUID addressId = UUID.randomUUID();
-        ReqUpdateAddressDtoV1 request = ReqUpdateAddressDtoV1.builder()
-                .alias("새집").address("서울특별시 중구").build();
-        ResGetAddressDtoV1 response = ResGetAddressDtoV1.builder()
-                .addressId(addressId).alias("새집").build();
+        ReqUpdateAddressDtoV1 request = ReqUpdateAddressDtoV1.builder().address("해킹시도").build();
         
-        given(addressService.updateAddress(eq(addressId), any(), eq(userId))).willReturn(response);
-
-        mockMvc.perform(put("/api/v1/addresses/" + addressId)
-                        .with(user(authUser))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk());
-    }
-
-    @Test
-    @DisplayName("[실패] 타인의 배송지 수정 시도 시 403 Forbidden 반환")
-    void updateAddressForbiddenTest() throws Exception {
-        UUID addressId = UUID.randomUUID();
-        ReqUpdateAddressDtoV1 request = ReqUpdateAddressDtoV1.builder().address("몰래수정").build();
-        
-        // 서비스에서 소유권 에러를 던지도록 설정
-        given(addressService.updateAddress(eq(addressId), any(), eq(userId)))
+        given(addressService.updateAddress(eq(addressId), any(), eq(userId), eq(UserRole.CUSTOMER)))
                 .willThrow(new CustomException(ErrorCode.ADDRESS_NOT_OWNER));
 
         mockMvc.perform(put("/api/v1/addresses/" + addressId)
-                        .with(user(authUser))
+                        .with(user(customerUser))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isForbidden()) // 403 확인
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.code").value("AD002"));
     }
 
     @Test
-    @DisplayName("[성공] 배송지 삭제 API - 204 No Content")
-    void deleteAddressApiTest() throws Exception {
-        UUID addressId = UUID.randomUUID();
+    @DisplayName("[비즈니스 실패] 존재하지 않는 배송지 수정 시도 - 404 Not Found")
+    void updateAddress_NotFound() throws Exception {
+        UUID addressId = UUID.fromString("00000000-0000-0000-0000-000000000000");
+        ReqUpdateAddressDtoV1 request = ReqUpdateAddressDtoV1.builder().address("유령").build();
 
-        mockMvc.perform(delete("/api/v1/addresses/" + addressId)
-                        .with(user(authUser)))
+        given(addressService.updateAddress(eq(addressId), any(), eq(userId), eq(UserRole.CUSTOMER)))
+                .willThrow(new CustomException(ErrorCode.ADDRESS_NOT_FOUND));
+
+        mockMvc.perform(put("/api/v1/addresses/" + addressId)
+                        .with(user(customerUser))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("AD001"));
+    }
+
+    @Test
+    @DisplayName("[유효성 실패] 필수값(address) 누락 시 - 400 Bad Request")
+    void createAddress_ValidationError() throws Exception {
+        ReqCreateAddressDtoV1 request = ReqCreateAddressDtoV1.builder()
+                .alias("주소없음")
+                .address("") // @NotBlank 위반
+                .build();
+
+        mockMvc.perform(post("/api/v1/addresses")
+                        .with(user(customerUser))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("[성공] 배송지 삭제 API - 204 No Content (가이드 3-④)")
+    void deleteAddress_Success() throws Exception {
+        mockMvc.perform(delete("/api/v1/addresses/" + UUID.randomUUID())
+                        .with(user(customerUser)))
+                .andDo(MockMvcResultHandlers.print())
                 .andExpect(status().isNoContent());
     }
-}
+
+    @Test
+    @DisplayName("[요구사항] 페이지 사이즈 제한 - 100건 요청 시 기본 10건으로 제한되는지 확인")
+    void getMyAddresses_PagingLimit_Validation() throws Exception {
+        // Given
+        given(addressService.getMyAddresses(eq(userId), eq(UserRole.CUSTOMER), any(), any()))
+                .willReturn(new PageImpl<>(List.of()));
+
+        // When: size=100 이라는 허용되지 않은 사이즈로 요청
+        mockMvc.perform(get("/api/v1/addresses?size=100")
+                        .with(user(customerUser)))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isOk());
+
+        // Then: 서비스에는 교정된 사이즈인 10이 전달되어야 함 (argThat 검증)
+        org.mockito.Mockito.verify(addressService).getMyAddresses(
+                eq(userId), 
+                eq(UserRole.CUSTOMER), 
+                any(), 
+                org.mockito.ArgumentMatchers.argThat(pageable -> pageable.getPageSize() == 10)
+        );
+    }
+    }
+

--- a/src/test/java/com/example/whostolemyfood/address/AddressControllerTest.java
+++ b/src/test/java/com/example/whostolemyfood/address/AddressControllerTest.java
@@ -150,7 +150,7 @@ public class AddressControllerTest {
     }
 
     @Test
-    @DisplayName("[성공] 배송지 삭제 API - 204 No Content (가이드 3-④)")
+    @DisplayName("[성공] 배송지 삭제 API - 204 No Content")
     void deleteAddress_Success() throws Exception {
         mockMvc.perform(delete("/api/v1/addresses/" + UUID.randomUUID())
                         .with(user(customerUser)))

--- a/src/test/java/com/example/whostolemyfood/address/AddressRepositoryTest.java
+++ b/src/test/java/com/example/whostolemyfood/address/AddressRepositoryTest.java
@@ -1,11 +1,5 @@
 package com.example.whostolemyfood.address;
 
-/*
- * TODO: 타 도메인(Payment 등)의 Schema Migration 오류(PostgreSQL UUID 변환 실패)로 인해 임시 주석 처리.
- * 도메인 간 ERD 정합성 문제 해결 후 주석을 해제하여 테스트를 활성화해야 함.
- */
-
-/*
 import com.example.whostolemyfood.address.domain.entity.AddressEntity;
 import com.example.whostolemyfood.address.domain.repository.AddressRepository;
 import com.example.whostolemyfood.global.config.JpaAuditingConfig;
@@ -21,6 +15,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.UUID;
 
@@ -30,15 +25,66 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ActiveProfiles("test")
 @Import(JpaAuditingConfig.class)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@org.springframework.data.jpa.repository.config.EnableJpaRepositories(basePackageClasses = AddressRepository.class)
 @EntityScan(basePackageClasses = {AddressEntity.class, UserEntity.class})
 public class AddressRepositoryTest {
 
     @Autowired
     private AddressRepository addressRepository;
 
+    @Autowired
+    private jakarta.persistence.EntityManager entityManager; // 영속성 컨텍스트 수동 제어를 위해 주입
+
     @BeforeEach
     void setUp() {
         addressRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("삭제 시 softDelete를 호출하면 Soft Delete가 적용되어야 함")
+    void softDeleteTest() {
+        // Given
+        AddressEntity address = addressRepository.save(createAddress(UUID.randomUUID(), "집"));
+        addressRepository.saveAndFlush(address);
+
+        // When
+        address.softDelete(UUID.randomUUID());
+        addressRepository.saveAndFlush(address); // DB에 UPDATE 쿼리 강제 실행
+        
+        entityManager.clear(); // 1차 캐시를 비워 다시 DB에서 조회하도록 강제함
+
+        // Then
+        AddressEntity found = addressRepository.findById(address.getId()).orElseThrow();
+        assertThat(found.getIsDeleted()).isTrue();
+        assertThat(found.getDeletedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("단건 조회 시 삭제되지 않은 배송지면 정상 조회되어야 함")
+    void findByIdAndIsDeletedFalse_Success() {
+        // Given
+        AddressEntity address = addressRepository.save(createAddress(UUID.randomUUID(), "우리집"));
+
+        // When
+        AddressEntity found = addressRepository.findByIdAndIsDeletedFalse(address.getId()).orElseThrow();
+
+        // Then
+        assertThat(found.getAlias()).isEqualTo("우리집");
+    }
+
+    @Test
+    @DisplayName("단건 조회 시 삭제된 배송지면 Optional.empty()를 반환해야 함")
+    void findByIdAndIsDeletedFalse_Fail_Deleted() {
+        // Given
+        AddressEntity address = addressRepository.save(createAddress(UUID.randomUUID(), "삭제될집"));
+        address.softDelete(UUID.randomUUID());
+        addressRepository.saveAndFlush(address);
+
+        // When
+        java.util.Optional<AddressEntity> result = addressRepository.findByIdAndIsDeletedFalse(address.getId());
+
+        // Then
+        assertThat(result).isEmpty();
     }
 
     @Test
@@ -93,22 +139,6 @@ public class AddressRepositoryTest {
         assertThat(defaultAddress.getIsDefault()).isTrue();
     }
 
-    @Test
-    @DisplayName("삭제 시 softDelete를 호출하면 Soft Delete가 적용되어야 함")
-    void softDeleteTest() {
-        // Given
-        AddressEntity address = addressRepository.save(createAddress(UUID.randomUUID(), "집"));
-
-        // When
-        address.softDelete(UUID.randomUUID());
-        addressRepository.saveAndFlush(address);
-
-        // Then
-        AddressEntity found = addressRepository.findById(address.getId()).orElseThrow();
-        assertThat(found.getIsDeleted()).isTrue();
-        assertThat(found.getDeletedAt()).isNotNull();
-    }
-
     private AddressEntity createAddress(UUID userId, String alias) {
         return AddressEntity.builder()
                 .userId(userId)
@@ -118,4 +148,3 @@ public class AddressRepositoryTest {
                 .build();
     }
 }
-*/

--- a/src/test/java/com/example/whostolemyfood/address/AddressServiceTest.java
+++ b/src/test/java/com/example/whostolemyfood/address/AddressServiceTest.java
@@ -9,6 +9,10 @@ import com.example.whostolemyfood.address.presentation.dto.response.ResCreateAdd
 import com.example.whostolemyfood.address.presentation.dto.response.ResGetAddressDtoV1;
 import com.example.whostolemyfood.global.exception.CustomException;
 import com.example.whostolemyfood.global.exception.ErrorCode;
+import com.example.whostolemyfood.user.domain.entity.UserEntity;
+import com.example.whostolemyfood.user.domain.entity.UserRole;
+import com.example.whostolemyfood.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,6 +31,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -38,154 +43,158 @@ public class AddressServiceTest {
     @Mock
     private AddressRepository addressRepository;
 
+    @Mock
+    private UserRepository userRepository;
+
+    private UUID userId;
+    private UserEntity mockUser;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+        mockUser = UserEntity.builder()
+                .email("test@example.com")
+                .role(UserRole.CUSTOMER)
+                .build();
+        ReflectionTestUtils.setField(mockUser, "id", userId);
+        ReflectionTestUtils.setField(mockUser, "isDeleted", false);
+    }
+
+    private void mockUserCheck(UserRole role) {
+        ReflectionTestUtils.setField(mockUser, "userRole", role);
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+    }
+
+    /**
+     * [보안 재검증] 실시간 권한 대조 테스트
+     */
     @Test
-    @DisplayName("[성공] 배송지 생성 - 유효한 정보 입력 시 정상 저장")
-    void createAddressSuccessTest() {
-        // Given
-        UUID userId = UUID.randomUUID();
-        ReqCreateAddressDtoV1 request = ReqCreateAddressDtoV1.builder()
-                .alias("우리집").address("서울시").isDefault(true).build();
+    @DisplayName("[보안 실패] DB 권한 재검증 - 토큰의 Role과 실제 DB의 Role이 다를 경우 차단")
+    void security_Fail_AuthorityMismatch() {
+        // Given: 토큰 권한은 CUSTOMER인데, DB에는 MASTER로 바뀌어 있는 상황 가정
+        UserRole tokenRole = UserRole.CUSTOMER;
+        mockUserCheck(UserRole.MASTER); // DB 상태 업데이트
+
+        // When & Then
+        CustomException ex = assertThrows(CustomException.class, () -> 
+            addressService.createAddress(ReqCreateAddressDtoV1.builder().build(), userId, tokenRole));
         
-        given(addressRepository.save(any())).willAnswer(invocation -> {
-            AddressEntity address = invocation.getArgument(0);
-            ReflectionTestUtils.setField(address, "id", UUID.randomUUID());
-            return address;
-        });
-
-        // When
-        ResCreateAddressDtoV1 response = addressService.createAddress(request, userId);
-
-        // Then
-        assertThat(response.getAddressId()).isNotNull();
+        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.ACCESS_DENIED);
     }
 
     @Test
-    @DisplayName("[성공] 기본 배송지 설정 - 새로운 기본지 생성 시 기존 기본지는 해제")
-    void handleDefaultAddressTest() {
+    @DisplayName("[보안 실패] DB 권한 재검증 - 유저가 DB에 존재하지 않을 경우 USER_NOT_FOUND 발생")
+    void security_Fail_UserNotFound() {
         // Given
-        UUID userId = UUID.randomUUID();
-        AddressEntity existingDefault = AddressEntity.builder().isDefault(true).build();
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // When & Then
+        CustomException ex = assertThrows(CustomException.class, () -> 
+            addressService.getMyAddresses(userId, UserRole.CUSTOMER, null, PageRequest.of(0, 10)));
+        
+        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("[보안 실패] DB 권한 재검증 - 유저가 탈퇴(isDeleted=true) 상태인 경우 USER_NOT_FOUND 발생")
+    void security_Fail_UserDeleted() {
+        // Given
+        ReflectionTestUtils.setField(mockUser, "isDeleted", true); // 탈퇴 처리
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+
+        // When & Then
+        CustomException ex = assertThrows(CustomException.class, () -> 
+            addressService.deleteAddress(UUID.randomUUID(), userId, UserRole.CUSTOMER));
+        
+        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+
+    /**
+     * [비즈니스 로직] 기본 배송지 자동 전환 테스트
+     */
+    @Test
+    @DisplayName("[성공] 기본 배송지 전환 - 새로운 기본 주소 설정 시 기존 기본 주소는 해제됨")
+    void createAddress_Success_HandleDefaultAddress() {
+        // Given
+        mockUserCheck(UserRole.CUSTOMER);
+        ReqCreateAddressDtoV1 request = ReqCreateAddressDtoV1.builder()
+                .address("새로운 기본집").isDefault(true).build();
+        
+        // 기존에 이미 '기본 배송지'인 데이터가 있다고 가정
+        AddressEntity existingDefault = AddressEntity.builder()
+                .userId(userId).address("옛날 기본집").isDefault(true).build();
+        
         given(addressRepository.findByUserIdAndIsDefaultTrueAndIsDeletedFalse(userId))
                 .willReturn(Optional.of(existingDefault));
         
-        ReqCreateAddressDtoV1 request = ReqCreateAddressDtoV1.builder().isDefault(true).address("새 주소").build();
-        given(addressRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+        given(addressRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
 
         // When
-        addressService.createAddress(request, userId);
+        addressService.createAddress(request, userId, UserRole.CUSTOMER);
 
         // Then
-        assertThat(existingDefault.getIsDefault()).isFalse();
+        assertThat(existingDefault.getIsDefault()).isFalse(); // 기존꺼는 자동으로 꺼져야 함
     }
 
+    /**
+     * 소유권 및 Soft Delete] 삭제 인가 테스트
+     */
     @Test
-    @DisplayName("[성공] 배송지 목록 조회 - 별칭 검색어 포함 시 필터링 결과 반환")
-    void getMyAddressesWithSearchTest() {
+    @DisplayName("[인가 실패] 배송지 삭제 - 타인의 주소를 삭제 시도 시 ADDRESS_NOT_OWNER 발생")
+    void deleteAddress_Fail_NotOwner() {
         // Given
-        UUID userId = UUID.randomUUID();
-        AddressEntity address = AddressEntity.builder().alias("회사").build();
-        given(addressRepository.findAllByUserIdAndAliasContainingAndIsDeletedFalse(any(), any(), any()))
-                .willReturn(new PageImpl<>(List.of(address)));
-
-        // When
-        Page<ResGetAddressDtoV1> result = addressService.getMyAddresses(userId, "회사", PageRequest.of(0, 10));
-
-        // Then
-        assertThat(result.getContent().get(0).getAlias()).isEqualTo("회사");
-    }
-
-    @Test
-    @DisplayName("[성공] 배송지 수정 - 본인 소유 배송지일 경우 정보 업데이트")
-    void updateAddressSuccessTest() {
-        // Given
-        UUID userId = UUID.randomUUID();
+        mockUserCheck(UserRole.CUSTOMER);
         UUID addressId = UUID.randomUUID();
-        AddressEntity address = AddressEntity.builder()
-                .userId(userId) // 소유자 일치
-                .alias("옛날집")
-                .build();
-        ReflectionTestUtils.setField(address, "id", addressId);
-        
-        given(addressRepository.findByIdAndIsDeletedFalse(addressId)).willReturn(Optional.of(address));
-
-        ReqUpdateAddressDtoV1 request = ReqUpdateAddressDtoV1.builder().alias("새로운집").address("서울").build();
-
-        // When
-        ResGetAddressDtoV1 response = addressService.updateAddress(addressId, request, userId);
-
-        // Then
-        assertThat(response.getAlias()).isEqualTo("새로운집");
-    }
-
-    @Test
-    @DisplayName("[실패] 배송지 수정 - 타인의 배송지 수정 시 ADDRESS_NOT_OWNER 예외 발생")
-    void updateAddressNotOwnerTest() {
-        // Given
-        UUID ownerId = UUID.randomUUID();
         UUID otherUserId = UUID.randomUUID();
-        UUID addressId = UUID.randomUUID();
-        AddressEntity address = AddressEntity.builder()
-                .userId(ownerId) // 소유자 다름
-                .build();
         
-        given(addressRepository.findByIdAndIsDeletedFalse(addressId)).willReturn(Optional.of(address));
+        // 주인은 'otherUserId'인 배송지 정보
+        AddressEntity otherAddress = AddressEntity.builder().userId(otherUserId).build();
+        given(addressRepository.findByIdAndIsDeletedFalse(addressId)).willReturn(Optional.of(otherAddress));
 
-        // When
-        CustomException exception = assertThrows(CustomException.class, () -> 
-            addressService.updateAddress(addressId, ReqUpdateAddressDtoV1.builder().address("서울").build(), otherUserId)
-        );
-
-        // Then
-        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ADDRESS_NOT_OWNER);
-    }
-
-    @Test
-    @DisplayName("[실패] 배송지 수정 - 존재하지 않는 ID 조회 시 ADDRESS_NOT_FOUND 예외 발생")
-    void updateAddressNotFoundTest() {
-        // Given
-        UUID userId = UUID.randomUUID();
-        UUID addressId = UUID.randomUUID();
-        given(addressRepository.findByIdAndIsDeletedFalse(addressId)).willReturn(Optional.empty());
-
-        // When
-        CustomException exception = assertThrows(CustomException.class, () -> 
-            addressService.updateAddress(addressId, ReqUpdateAddressDtoV1.builder().address("서울").build(), userId)
-        );
-
-        // Then
-        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ADDRESS_NOT_FOUND);
-    }
-
-    @Test
-    @DisplayName("[실패] 배송지 삭제 - 타인의 배송지 삭제 시 ADDRESS_NOT_OWNER 예외 발생")
-    void deleteAddressNotOwnerTest() {
-        // Given
-        UUID ownerId = UUID.randomUUID();
-        UUID otherUserId = UUID.randomUUID();
-        UUID addressId = UUID.randomUUID();
-        AddressEntity address = AddressEntity.builder().userId(ownerId).build();
+        // When & Then
+        CustomException ex = assertThrows(CustomException.class, () -> 
+            addressService.deleteAddress(addressId, userId, UserRole.CUSTOMER));
         
-        given(addressRepository.findByIdAndIsDeletedFalse(addressId)).willReturn(Optional.of(address));
-
-        // When
-        CustomException exception = assertThrows(CustomException.class, () -> addressService.deleteAddress(addressId, otherUserId));
-
-        // Then
-        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ADDRESS_NOT_OWNER);
+        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.ADDRESS_NOT_OWNER);
     }
 
     @Test
-    @DisplayName("[실패] 배송지 삭제 - 존재하지 않는 ID 조회 시 ADDRESS_NOT_FOUND 예외 발생")
-    void deleteAddressNotFoundTest() {
+    @DisplayName("[성공] 배송지 삭제 - 본인 소유인 경우 Soft Delete 정상 수행")
+    void deleteAddress_Success() {
         // Given
-        UUID userId = UUID.randomUUID();
+        mockUserCheck(UserRole.CUSTOMER);
         UUID addressId = UUID.randomUUID();
-        given(addressRepository.findByIdAndIsDeletedFalse(addressId)).willReturn(Optional.empty());
+        AddressEntity myAddress = AddressEntity.builder().userId(userId).build();
+        ReflectionTestUtils.setField(myAddress, "id", addressId);
+        
+        given(addressRepository.findByIdAndIsDeletedFalse(addressId)).willReturn(Optional.of(myAddress));
 
         // When
-        CustomException exception = assertThrows(CustomException.class, () -> addressService.deleteAddress(addressId, userId));
+        addressService.deleteAddress(addressId, userId, UserRole.CUSTOMER);
 
         // Then
-        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ADDRESS_NOT_FOUND);
+        assertThat(myAddress.getIsDeleted()).isTrue(); // Soft Delete 확인
+    }
+
+    /**
+     * [조회 및 필터링] 목록 검색 테스트
+     */
+    @Test
+    @DisplayName("[성공] 본인 배송지 목록 조회 - 별칭 검색어 필터링 연동 확인")
+    void getMyAddresses_WithFiltering_Success() {
+        // Given
+        mockUserCheck(UserRole.CUSTOMER);
+        String searchAlias = "우리집";
+        AddressEntity filteredAddress = AddressEntity.builder().userId(userId).alias(searchAlias).build();
+        
+        given(addressRepository.findAllByUserIdAndAliasContainingAndIsDeletedFalse(eq(userId), eq(searchAlias), any()))
+                .willReturn(new PageImpl<>(List.of(filteredAddress)));
+
+        // When
+        Page<ResGetAddressDtoV1> result = addressService.getMyAddresses(userId, UserRole.CUSTOMER, searchAlias, PageRequest.of(0, 10));
+
+        // Then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getAlias()).isEqualTo(searchAlias);
     }
 }

--- a/src/test/java/com/example/whostolemyfood/order/OrderControllerTest.java
+++ b/src/test/java/com/example/whostolemyfood/order/OrderControllerTest.java
@@ -2,6 +2,8 @@ package com.example.whostolemyfood.order;
 
 import com.example.whostolemyfood.global.config.security.SecurityConfig;
 import com.example.whostolemyfood.global.config.security.jwt.JwtUtil;
+import com.example.whostolemyfood.global.exception.CustomException;
+import com.example.whostolemyfood.global.exception.ErrorCode;
 import com.example.whostolemyfood.global.exception.GlobalExceptionHandler;
 import com.example.whostolemyfood.order.application.service.OrderServiceV1;
 import com.example.whostolemyfood.order.domain.entity.OrderStatus;
@@ -11,6 +13,7 @@ import com.example.whostolemyfood.order.presentation.dto.request.ReqUpdateOrderR
 import com.example.whostolemyfood.order.presentation.dto.request.ReqUpdateOrderStatusDtoV1;
 import com.example.whostolemyfood.order.presentation.dto.response.ResCreateOrderDtoV1;
 import com.example.whostolemyfood.order.presentation.dto.response.ResGetOrderDtoV1;
+import com.example.whostolemyfood.order.presentation.dto.response.ResGetOrderListDtoV1;
 import com.example.whostolemyfood.user.application.security.AuthUser;
 import com.example.whostolemyfood.user.domain.entity.UserRole;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -25,6 +28,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
 import java.util.List;
 import java.util.UUID;
@@ -55,6 +59,7 @@ public class OrderControllerTest {
     private JwtUtil jwtUtil;
 
     private AuthUser customerUser;
+    private AuthUser ownerUser;
     private AuthUser masterUser;
     private UUID userId;
 
@@ -62,12 +67,13 @@ public class OrderControllerTest {
     void setUp() {
         userId = UUID.randomUUID();
         customerUser = new AuthUser(userId, "customer@example.com", UserRole.CUSTOMER);
+        ownerUser = new AuthUser(UUID.randomUUID(), "owner@example.com", UserRole.OWNER);
         masterUser = new AuthUser(UUID.randomUUID(), "master@example.com", UserRole.MASTER);
     }
 
     @Test
-    @DisplayName("[성공] 주문 생성 - 200 OK")
-    void createOrderApiTest() throws Exception {
+    @DisplayName("[인가 성공] 주문 생성 API - CUSTOMER 접근 시 200 OK")
+    void createOrder_Authorized() throws Exception {
         ReqCreateOrderDtoV1 request = ReqCreateOrderDtoV1.builder()
                 .storeId(UUID.randomUUID()).addressId(UUID.randomUUID())
                 .orderItems(List.of(ReqCreateOrderDtoV1.OrderItemRequest.builder().menuId(UUID.randomUUID()).quantity(1).priceAtOrder(10000).build()))
@@ -80,81 +86,64 @@ public class OrderControllerTest {
                         .with(user(customerUser))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
+                .andDo(MockMvcResultHandlers.print())
                 .andExpect(status().isOk());
     }
 
     @Test
-    @DisplayName("[성공] 주문 목록 조회 - 200 OK")
-    void getOrdersApiTest() throws Exception {
+    @DisplayName("[인가 실패] 주문 상태 변경 - CUSTOMER 접근 시 403 Forbidden")
+    void updateOrderStatus_Forbidden_Customer() throws Exception {
+        UUID orderId = UUID.randomUUID();
+        ReqUpdateOrderStatusDtoV1 request = new ReqUpdateOrderStatusDtoV1(OrderStatus.ACCEPTED);
+
+        mockMvc.perform(patch("/api/v1/orders/" + orderId + "/status")
+                        .with(user(customerUser)) // 고객은 상태 변경 불가
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("[인가 실패] 주문 삭제 시도 - CUSTOMER가 호출 시 403 Forbidden")
+    void deleteOrder_Forbidden() throws Exception {
+        mockMvc.perform(delete("/api/v1/orders/" + UUID.randomUUID())
+                        .with(user(customerUser)))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("[요구사항] 페이지 사이즈 제한 - 100건 요청 시 기본 10건으로 제한되는지 확인")
+    void getOrders_PagingLimit_Validation() throws Exception {
+        // Given
         given(orderService.getOrders(any(), any(), any(), eq(userId), eq(UserRole.CUSTOMER)))
                 .willReturn(new PageImpl<>(List.of()));
 
-        mockMvc.perform(get("/api/v1/orders")
+        // When: size=100 요청
+        mockMvc.perform(get("/api/v1/orders?size=100")
                         .with(user(customerUser)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.content").isArray());
-    }
-
-    @Test
-    @DisplayName("[성공] 주문 상세 조회 - 200 OK")
-    void getOrderApiTest() throws Exception {
-        UUID orderId = UUID.randomUUID();
-        ResGetOrderDtoV1 response = ResGetOrderDtoV1.builder().orderId(orderId).build();
-        given(orderService.getOrder(eq(orderId), eq(userId), eq(UserRole.CUSTOMER))).willReturn(response);
-
-        mockMvc.perform(get("/api/v1/orders/" + orderId)
-                        .with(user(customerUser)))
+                .andDo(MockMvcResultHandlers.print())
                 .andExpect(status().isOk());
+
+        // Then: 서비스에는 10이 전달되어야 함 (verify + argThat)
+        org.mockito.Mockito.verify(orderService).getOrders(
+                any(), any(), 
+                org.mockito.ArgumentMatchers.argThat(pageable -> pageable.getPageSize() == 10),
+                eq(userId), eq(UserRole.CUSTOMER)
+        );
     }
 
     @Test
-    @DisplayName("[성공] 요청사항 수정 - 200 OK")
-    void updateOrderRequestApiTest() throws Exception {
+    @DisplayName("[성공] 관리자 슈퍼 취소 - MASTER는 200 OK")
+    void cancelOrder_ByMaster() throws Exception {
         UUID orderId = UUID.randomUUID();
-        ReqUpdateOrderRequestDtoV1 request = new ReqUpdateOrderRequestDtoV1("수정된 요청");
-        given(orderService.updateOrderRequest(eq(orderId), any(), eq(userId), eq(UserRole.CUSTOMER)))
-                .willReturn(ResGetOrderDtoV1.builder().orderId(orderId).build());
-
-        mockMvc.perform(put("/api/v1/orders/" + orderId)
-                        .with(user(customerUser))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk());
-    }
-
-    @Test
-    @DisplayName("[성공] 상태 변경 - 200 OK")
-    void updateOrderStatusApiTest() throws Exception {
-        UUID orderId = UUID.randomUUID();
-        ReqUpdateOrderStatusDtoV1 request = new ReqUpdateOrderStatusDtoV1(OrderStatus.ACCEPTED);
-        given(orderService.updateOrderStatus(eq(orderId), any(), eq(userId), eq(UserRole.CUSTOMER)))
-                .willReturn(ResGetOrderDtoV1.builder().orderId(orderId).build());
-
-        mockMvc.perform(patch("/api/v1/orders/" + orderId + "/status")
-                        .with(user(customerUser))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk());
-    }
-
-    @Test
-    @DisplayName("[성공] 주문 취소 - 200 OK")
-    void cancelOrderApiTest() throws Exception {
-        UUID orderId = UUID.randomUUID();
-        given(orderService.cancelOrder(eq(orderId), eq(userId), eq(UserRole.CUSTOMER)))
+        given(orderService.cancelOrder(eq(orderId), any(), eq(UserRole.MASTER)))
                 .willReturn(ResGetOrderDtoV1.builder().orderId(orderId).build());
 
         mockMvc.perform(patch("/api/v1/orders/" + orderId + "/cancel")
-                        .with(user(customerUser)))
-                .andExpect(status().isOk());
-    }
-
-    @Test
-    @DisplayName("[성공] 주문 삭제 - 204 No Content")
-    void deleteOrderApiTest() throws Exception {
-        UUID orderId = UUID.randomUUID();
-        mockMvc.perform(delete("/api/v1/orders/" + orderId)
                         .with(user(masterUser)))
-                .andExpect(status().isNoContent());
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isOk());
     }
 }

--- a/src/test/java/com/example/whostolemyfood/order/OrderRepositoryTest.java
+++ b/src/test/java/com/example/whostolemyfood/order/OrderRepositoryTest.java
@@ -1,19 +1,16 @@
 package com.example.whostolemyfood.order;
 
-/*
- * TODO: 타 도메인(ReviewRepository)의 메서드 시그니처 오류(Pageable 누락)로 인해
- * 애플리케이션 컨텍스트 로드 실패가 발생하여 임시 주석 처리함.
- */
-
-/*
 import com.example.whostolemyfood.global.config.JpaAuditingConfig;
 import com.example.whostolemyfood.order.domain.entity.OrderEntity;
+import com.example.whostolemyfood.order.domain.entity.OrderItemEntity;
 import com.example.whostolemyfood.order.domain.entity.OrderStatus;
 import com.example.whostolemyfood.order.domain.repository.OrderRepository;
+import com.example.whostolemyfood.user.domain.entity.UserEntity;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
@@ -29,10 +26,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ActiveProfiles("test")
 @Import(JpaAuditingConfig.class)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@org.springframework.data.jpa.repository.config.EnableJpaRepositories(basePackageClasses = OrderRepository.class)
+@EntityScan(basePackageClasses = {OrderEntity.class, OrderItemEntity.class, UserEntity.class})
 public class OrderRepositoryTest {
 
     @Autowired
     private OrderRepository orderRepository;
+
+    @Autowired
+    private jakarta.persistence.EntityManager entityManager;
 
     @BeforeEach
     void setUp() {
@@ -40,48 +42,45 @@ public class OrderRepositoryTest {
     }
 
     @Test
-    @DisplayName("[레포지토리] 기본 페이징 조회 시 삭제되지 않은 주문만 조회되어야 함")
-    void findAllByIsDeletedFalseTest() {
-        OrderEntity activeOrder = orderRepository.save(createOrder(UUID.randomUUID()));
-        OrderEntity deletedOrder = orderRepository.save(createOrder(UUID.randomUUID()));
-        deletedOrder.softDelete(UUID.randomUUID());
-        orderRepository.saveAndFlush(deletedOrder);
-
-        Page<OrderEntity> result = orderRepository.findAllByIsDeletedFalse(PageRequest.of(0, 10));
-
-        assertThat(result.getTotalElements()).isEqualTo(1L);
-        assertThat(result.getContent().get(0).getOrderId()).isEqualTo(activeOrder.getOrderId());
-    }
-
-    @Test
-    @DisplayName("[레포지토리] 특정 가게의 주문만 필터링 조회")
-    void findAllByStoreIdAndIsDeletedFalseTest() {
-        UUID storeA = UUID.randomUUID();
-        orderRepository.save(createOrder(storeA));
-        orderRepository.save(createOrder(storeA));
-        orderRepository.save(createOrder(UUID.randomUUID())); 
-
-        Page<OrderEntity> orders = orderRepository.findAllByStoreIdAndIsDeletedFalse(storeA, PageRequest.of(0, 10));
-
-        assertThat(orders.getTotalElements()).isEqualTo(2L);
-    }
-
-    @Test
-    @DisplayName("[레포지토리] 주문 Soft Delete 시 삭제 시간 및 삭제자 기록 확인")
-    void softDeleteAuditTest() {
-        UUID deleterId = UUID.randomUUID();
+    @DisplayName("[레포지토리] Soft Delete 확실성 검증 - flush & clear 후에도 상태 유지 확인")
+    void softDelete_StaysDeleted() {
+        // Given
         OrderEntity order = orderRepository.save(createOrder(UUID.randomUUID()));
-        
-        order.softDelete(deleterId);
         orderRepository.saveAndFlush(order);
 
-        OrderEntity foundOrder = orderRepository.findById(order.getOrderId()).orElseThrow();
-        assertThat(foundOrder.getIsDeleted()).isTrue();
-        assertThat(foundOrder.getDeletedAt()).isNotNull();
-        assertThat(foundOrder.getDeletedBy()).isEqualTo(deleterId);
+        // When
+        order.softDelete(UUID.randomUUID());
+        orderRepository.saveAndFlush(order);
+        entityManager.clear(); // 1차 캐시 비우기
+
+        // Then
+        OrderEntity found = orderRepository.findById(order.getOrderId()).orElseThrow();
+        assertThat(found.getIsDeleted()).isTrue();
+        assertThat(found.getDeletedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("[레포지토리] 특정 가게(storeId)의 노출된(isHidden=false) 주문만 페이징 조회")
+    void findAllByStoreIdAndIsHiddenAndIsDeletedFalseTest() {
+        // Given
+        UUID storeId = UUID.randomUUID();
+        orderRepository.save(createOrder(storeId, false)); // 대상
+        orderRepository.save(createOrder(storeId, true));  // 숨김 처리됨
+        orderRepository.save(createOrder(UUID.randomUUID(), false)); // 다른 가게
+
+        // When
+        Page<OrderEntity> result = orderRepository.findAllByStoreIdAndIsHiddenAndIsDeletedFalse(
+                storeId, false, PageRequest.of(0, 10));
+
+        // Then
+        assertThat(result.getTotalElements()).isEqualTo(1L);
     }
 
     private OrderEntity createOrder(UUID storeId) {
+        return createOrder(storeId, false);
+    }
+
+    private OrderEntity createOrder(UUID storeId, boolean isHidden) {
         return OrderEntity.builder()
                 .userId(UUID.randomUUID())
                 .storeId(storeId)
@@ -89,8 +88,7 @@ public class OrderRepositoryTest {
                 .totalPrice(13000)
                 .deliveryFee(3000)
                 .status(OrderStatus.PENDING)
-                .isHidden(false)
+                .isHidden(isHidden)
                 .build();
     }
 }
-*/

--- a/src/test/java/com/example/whostolemyfood/order/OrderServiceTest.java
+++ b/src/test/java/com/example/whostolemyfood/order/OrderServiceTest.java
@@ -8,27 +8,33 @@ import com.example.whostolemyfood.menu.domain.entity.MenuEntity;
 import com.example.whostolemyfood.menu.domain.repository.MenuRepository;
 import com.example.whostolemyfood.order.application.service.OrderServiceV1;
 import com.example.whostolemyfood.order.domain.entity.OrderEntity;
-import com.example.whostolemyfood.order.domain.entity.OrderItemEntity;
 import com.example.whostolemyfood.order.domain.entity.OrderStatus;
 import com.example.whostolemyfood.order.domain.repository.OrderRepository;
 import com.example.whostolemyfood.order.presentation.dto.request.ReqCreateOrderDtoV1;
 import com.example.whostolemyfood.order.presentation.dto.response.ResCreateOrderDtoV1;
 import com.example.whostolemyfood.order.presentation.dto.response.ResGetOrderDtoV1;
+import com.example.whostolemyfood.order.presentation.dto.response.ResGetOrderListDtoV1;
 import com.example.whostolemyfood.store.domain.entity.StoreEntity;
 import com.example.whostolemyfood.store.domain.entity.StoreStatus;
 import com.example.whostolemyfood.store.domain.repository.StoreRepository;
 import com.example.whostolemyfood.user.domain.entity.UserEntity;
 import com.example.whostolemyfood.user.domain.entity.UserRole;
+import com.example.whostolemyfood.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -36,6 +42,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -52,98 +59,195 @@ public class OrderServiceTest {
     private MenuRepository menuRepository;
     @Mock
     private AddressRepository addressRepository;
+    @Mock
+    private UserRepository userRepository;
 
-    @Test
-    @DisplayName("[성공] 주문 생성 - CUSTOMER 권한으로 모든 검증 통과")
-    void createOrderSuccessTest() {
-        UUID userId = UUID.randomUUID();
-        UUID storeId = UUID.randomUUID();
-        ReqCreateOrderDtoV1 request = ReqCreateOrderDtoV1.builder()
-                .storeId(storeId).addressId(UUID.randomUUID())
-                .orderItems(List.of(ReqCreateOrderDtoV1.OrderItemRequest.builder()
-                        .menuId(UUID.randomUUID()).quantity(2).priceAtOrder(10000).build()))
+    private UUID userId;
+    private UserEntity mockUser;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+        mockUser = UserEntity.builder()
+                .email("test@example.com")
+                .role(UserRole.CUSTOMER)
                 .build();
+        ReflectionTestUtils.setField(mockUser, "id", userId);
+        ReflectionTestUtils.setField(mockUser, "isDeleted", false);
+    }
 
-        StoreEntity store = StoreEntity.builder().status(StoreStatus.OPEN).openTime(LocalTime.MIN).closeTime(LocalTime.MAX).minOrderPrice(5000).build();
-        given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
-        given(addressRepository.findByIdAndIsDeletedFalse(any())).willReturn(Optional.of(AddressEntity.builder().userId(userId).build()));
-        given(menuRepository.findById(any())).willReturn(Optional.of(MenuEntity.builder().price(10000).build()));
+    private void mockUserCheck(UserRole role) {
+        ReflectionTestUtils.setField(mockUser, "userRole", role);
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+    }
 
-        given(orderRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
-
-        ResCreateOrderDtoV1 response = orderService.createOrder(request, userId, UserRole.CUSTOMER);
-        assertThat(response).isNotNull();
+    /**
+     * [보안 재검증] validateUserRoleFromDB 3종 세트
+     */
+    @Test
+    @DisplayName("[보안 실패] DB 권한 재검증 - 토큰의 Role과 실제 DB의 Role이 다를 경우 차단")
+    void security_Fail_AuthorityMismatch() {
+        mockUserCheck(UserRole.MASTER);
+        assertThrows(CustomException.class, () -> 
+            orderService.createOrder(ReqCreateOrderDtoV1.builder().build(), userId, UserRole.CUSTOMER));
     }
 
     @Test
-    @DisplayName("[실패] 주문 생성 - OWNER 권한으로 주문 시도 시 차단 (SA 준수)")
-    void createOrderFailByRoleTest() {
-        CustomException ex = assertThrows(CustomException.class, 
-                () -> orderService.createOrder(ReqCreateOrderDtoV1.builder().build(), UUID.randomUUID(), UserRole.OWNER));
-        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.ACCESS_DENIED);
+    @DisplayName("[보안 실패] 유저 부재/탈퇴 - 유저가 DB에 없거나 삭제된 경우 차단")
+    void security_Fail_UserNotFoundOrDeleted() {
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+        assertThrows(CustomException.class, () -> orderService.getOrder(UUID.randomUUID(), userId, UserRole.CUSTOMER));
     }
 
+    /**
+     * [성공 케이스] 사장님(OWNER)의 주문 상태 업데이트 순차 흐름 테스트
+     * - PENDING -> ACCEPTED -> COOKING -> DELIVERING -> DELIVERED -> COMPLETED
+     */
     @Test
-    @DisplayName("[성공] 상태 변경 - OWNER가 본인 가게 주문을 순차적으로 변경 (PENDING -> ACCEPTED)")
-    void updateOrderStatusSuccessByOwnerTest() {
+    @DisplayName("[성공] 상태 업데이트 흐름 - 사장님이 비즈니스 규칙에 맞게 단계를 하나씩 진행")
+    void updateOrderStatus_FullFlow_ByOwner() {
+        // Given
         UUID ownerId = UUID.randomUUID();
         UUID storeId = UUID.randomUUID();
+        ReflectionTestUtils.setField(mockUser, "id", ownerId);
+        ReflectionTestUtils.setField(mockUser, "userRole", UserRole.OWNER);
+        given(userRepository.findById(ownerId)).willReturn(Optional.of(mockUser));
+
+        // 초기 상태: PENDING
         OrderEntity order = OrderEntity.builder().storeId(storeId).status(OrderStatus.PENDING).build();
         given(orderRepository.findById(any())).willReturn(Optional.of(order));
 
-        UserEntity owner = UserEntity.builder().build();
-        ReflectionTestUtils.setField(owner, "id", ownerId);
-        StoreEntity store = StoreEntity.builder().user(owner).build();
+        UserEntity ownerEntity = UserEntity.builder().build();
+        ReflectionTestUtils.setField(ownerEntity, "id", ownerId);
+        StoreEntity store = StoreEntity.builder().user(ownerEntity).build();
         given(storeRepository.findById(storeId)).willReturn(Optional.of(store));
 
-        ResGetOrderDtoV1 response = orderService.updateOrderStatus(UUID.randomUUID(), OrderStatus.ACCEPTED, ownerId, UserRole.OWNER);
-        assertThat(response.getStatus()).isEqualTo(OrderStatus.ACCEPTED);
+        // When & Then (순차적 전이 검증)
+        // 1. PENDING -> ACCEPTED
+        orderService.updateOrderStatus(order.getOrderId(), OrderStatus.ACCEPTED, ownerId, UserRole.OWNER);
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.ACCEPTED);
+
+        // 2. ACCEPTED -> COOKING
+        orderService.updateOrderStatus(order.getOrderId(), OrderStatus.COOKING, ownerId, UserRole.OWNER);
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.COOKING);
+
+        // 3. COOKING -> DELIVERING
+        orderService.updateOrderStatus(order.getOrderId(), OrderStatus.DELIVERING, ownerId, UserRole.OWNER);
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.DELIVERING);
+
+        // 4. DELIVERING -> DELIVERED
+        orderService.updateOrderStatus(order.getOrderId(), OrderStatus.DELIVERED, ownerId, UserRole.OWNER);
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.DELIVERED);
+
+        // 5. DELIVERED -> COMPLETED
+        orderService.updateOrderStatus(order.getOrderId(), OrderStatus.COMPLETED, ownerId, UserRole.OWNER);
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.COMPLETED);
     }
 
+    /**
+     * [비즈니스 방어] 상태에 따른 수정 불가 검증
+     */
     @Test
-    @DisplayName("[실패] 상태 변경 - OWNER가 순서를 건너뛰려 할 때 차단 (ACCEPTED -> DELIVERED)")
-    void updateOrderStatusJumpFailByOwnerTest() {
-        UUID ownerId = UUID.randomUUID();
+    @DisplayName("[비즈니스 실패] 요청사항 수정 차단 - 이미 조리 중인 주문은 수정할 수 없음")
+    void updateOrderRequest_Fail_WhenAlreadyCooking() {
+        mockUserCheck(UserRole.CUSTOMER);
+        OrderEntity cookingOrder = OrderEntity.builder().userId(userId).status(OrderStatus.COOKING).build();
+        given(orderRepository.findById(any())).willReturn(Optional.of(cookingOrder));
+
+        CustomException ex = assertThrows(CustomException.class, () -> 
+            orderService.updateOrderRequest(UUID.randomUUID(), "지금이라도 오이 빼주세요", userId, UserRole.CUSTOMER));
+        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.ORDER_REQUEST_UPDATE_FAILED);
+    }
+
+    /**
+     * [조회 안정성] 검색 결과가 없을 때 (Empty Page)
+     */
+    @Test
+    @DisplayName("[성공] 주문 목록 조회 - 검색 결과가 없는 경우 빈 페이지를 반환함")
+    void getOrders_ReturnEmptyPage_WhenNoOrdersMatch() {
         UUID storeId = UUID.randomUUID();
-        OrderEntity order = OrderEntity.builder().storeId(storeId).status(OrderStatus.ACCEPTED).build(); // 현재 수락됨
+        mockUserCheck(UserRole.MANAGER);
+        given(orderRepository.findAllByStoreIdAndIsDeletedFalse(eq(storeId), any()))
+                .willReturn(new PageImpl<>(Collections.emptyList()));
+
+        Page<ResGetOrderListDtoV1> result = orderService.getOrders(storeId, null, PageRequest.of(0, 10), userId, UserRole.MANAGER);
+
+        assertThat(result.isEmpty()).isTrue();
+        assertThat(result.getTotalElements()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("[성공] 주문 취소 - 5분 이내 정상 취소")
+    void cancelOrder_Success_Within5Min() {
+        mockUserCheck(UserRole.CUSTOMER);
+        OrderEntity order = OrderEntity.builder().userId(userId).status(OrderStatus.PENDING).build();
+        ReflectionTestUtils.setField(order, "createdAt", LocalDateTime.now().minusMinutes(2)); 
         given(orderRepository.findById(any())).willReturn(Optional.of(order));
 
-        UserEntity owner = UserEntity.builder().build();
-        ReflectionTestUtils.setField(owner, "id", ownerId);
-        given(storeRepository.findById(storeId)).willReturn(Optional.of(StoreEntity.builder().user(owner).build()));
-
-        // 사장님은 ACCEPTED 다음에 바로 DELIVERED로 갈 수 없음 (중간 단계 누락)
-        assertThrows(CustomException.class, 
-                () -> orderService.updateOrderStatus(UUID.randomUUID(), OrderStatus.DELIVERED, ownerId, UserRole.OWNER));
+        ResGetOrderDtoV1 response = orderService.cancelOrder(UUID.randomUUID(), userId, UserRole.CUSTOMER);
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
     }
 
+    /**
+     * [추가 실패 케이스] 가게 운영 정책 위반 시 주문 생성 차단
+     */
     @Test
-    @DisplayName("[성공] 상태 변경 - MASTER 권한은 모든 순서를 무시하고 강제 변경 가능 (슈퍼 권한)")
-    void updateOrderStatusForceByMasterTest() {
-        OrderEntity order = OrderEntity.builder().status(OrderStatus.PENDING).build(); // 현재 대기중
-        given(orderRepository.findById(any())).willReturn(Optional.of(order));
+    @DisplayName("[비즈니스 실패] 주문 생성 차단 - 가게가 CLOSED 상태거나 최소 주문 금액 미달 시 예외 발생")
+    void createOrder_Fail_StorePolicyViolation() {
+        // Given 1: 가게가 CLOSED 상태인 경우
+        mockUserCheck(UserRole.CUSTOMER);
+        UUID storeId = UUID.randomUUID();
+        StoreEntity closedStore = StoreEntity.builder().status(StoreStatus.CLOSED).isHidden(false).build();
+        given(storeRepository.findById(storeId)).willReturn(Optional.of(closedStore));
 
-        // MASTER는 PENDING에서 바로 COMPLETED로 점프 가능
-        ResGetOrderDtoV1 response = orderService.updateOrderStatus(UUID.randomUUID(), OrderStatus.COMPLETED, UUID.randomUUID(), UserRole.MASTER);
-        assertThat(response.getStatus()).isEqualTo(OrderStatus.COMPLETED);
+        ReqCreateOrderDtoV1 request = ReqCreateOrderDtoV1.builder().storeId(storeId).build();
+
+        // When & Then 1
+        assertThat(assertThrows(CustomException.class, () -> 
+            orderService.createOrder(request, userId, UserRole.CUSTOMER)).getErrorCode())
+            .isEqualTo(ErrorCode.STORE_CLOSED);
+
+        // Given 2: 최소 주문 금액 미달인 경우
+        StoreEntity openStore = StoreEntity.builder()
+                .status(StoreStatus.OPEN).openTime(LocalTime.MIN).closeTime(LocalTime.MAX)
+                .minOrderPrice(50000).isHidden(false).build(); // 최소 5만원
+        given(storeRepository.findById(storeId)).willReturn(Optional.of(openStore));
+        given(addressRepository.findByIdAndIsDeletedFalse(any())).willReturn(Optional.of(AddressEntity.builder().userId(userId).build()));
+        given(menuRepository.findById(any())).willReturn(Optional.of(MenuEntity.builder().price(10000).build())); // 1만원만 주문
+
+        ReqCreateOrderDtoV1 minPriceRequest = ReqCreateOrderDtoV1.builder()
+                .storeId(storeId).addressId(UUID.randomUUID())
+                .orderItems(List.of(ReqCreateOrderDtoV1.OrderItemRequest.builder().menuId(UUID.randomUUID()).quantity(1).priceAtOrder(10000).build()))
+                .build();
+
+        // When & Then 2
+        assertThat(assertThrows(CustomException.class, () -> 
+            orderService.createOrder(minPriceRequest, userId, UserRole.CUSTOMER)).getErrorCode())
+            .isEqualTo(ErrorCode.ORDER_MIN_PRICE_NOT_MET);
     }
 
+    /**
+     * 6. [추가 실패 케이스] 권한 없는 제3자의 접근 차단
+     */
     @Test
-    @DisplayName("[성공] 주문 취소 - MASTER는 5분 제한 없이 강제 취소 가능 (SA 준수)")
-    void cancelOrderByMasterTest() {
-        OrderEntity oldOrder = OrderEntity.builder().status(OrderStatus.PENDING).build();
-        ReflectionTestUtils.setField(oldOrder, "createdAt", LocalDateTime.now().minusMinutes(10)); // 10분 전 주문
-        given(orderRepository.findById(any())).willReturn(Optional.of(oldOrder));
+    @DisplayName("[보안 실패] 주문 상세 조회 차단 - 본인이나 가게 사장님이 아닌 제3자가 조회 시 예외 발생")
+    void getOrder_Fail_UnauthorizedAccess() {
+        // Given: 주문 유저는 A인데, 조회 요청자는 B인 상황
+        UUID userA = UUID.randomUUID();
+        UUID userB = userId; // BeforeEach에서 세팅된 userId를 사용함
 
-        ResGetOrderDtoV1 response = orderService.cancelOrder(UUID.randomUUID(), UUID.randomUUID(), UserRole.MASTER);
-        assertThat(response.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+        // mockUserCheck(UserRole.CUSTOMER) 하나로 DB 조회 결과 세팅 완료
+        mockUserCheck(UserRole.CUSTOMER); 
+
+        OrderEntity orderOfUserA = OrderEntity.builder().userId(userA).storeId(UUID.randomUUID()).build();
+        given(orderRepository.findById(any())).willReturn(Optional.of(orderOfUserA));
+        // 제거: CUSTOMER 권한 조회 시에는 storeRepository.findById가 호출되지 않으므로 UnnecessaryStubbing 발생
+
+        // When & Then
+        CustomException ex = assertThrows(CustomException.class, () -> 
+            orderService.getOrder(UUID.randomUUID(), userB, UserRole.CUSTOMER));
+        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.ORDER_NOT_OWNER);
+    }
     }
 
-    @Test
-    @DisplayName("[실패] 주문 삭제 - 오직 MASTER만 가능하며 MANAGER는 거부됨 (SA 준수)")
-    void deleteOrderFailByManagerTest() {
-        CustomException ex = assertThrows(CustomException.class, 
-                () -> orderService.deleteOrder(UUID.randomUUID(), UUID.randomUUID(), UserRole.MANAGER));
-        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.ACCESS_DENIED);
-    }
-}
+

--- a/src/test/java/com/example/whostolemyfood/order/OrderServiceTest.java
+++ b/src/test/java/com/example/whostolemyfood/order/OrderServiceTest.java
@@ -188,6 +188,23 @@ public class OrderServiceTest {
         assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
     }
 
+    @Test
+    @DisplayName("[실패] 주문 취소 - CUSTOMER가 5분을 초과한 경우 취소 실패 (요구사항)")
+    void cancelOrder_Fail_TimeExceeded() {
+        // Given
+        mockUserCheck(UserRole.CUSTOMER);
+        OrderEntity order = OrderEntity.builder().userId(userId).status(OrderStatus.PENDING).build();
+        // 6분 전으로 강제 설정
+        ReflectionTestUtils.setField(order, "createdAt", LocalDateTime.now().minusMinutes(6)); 
+        
+        given(orderRepository.findById(any())).willReturn(Optional.of(order));
+
+        // When & Then
+        CustomException ex = assertThrows(CustomException.class, () -> 
+            orderService.cancelOrder(UUID.randomUUID(), userId, UserRole.CUSTOMER));
+        assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.ORDER_CANCEL_TIME_EXCEEDED);
+    }
+
     /**
      * [추가 실패 케이스] 가게 운영 정책 위반 시 주문 생성 차단
      */
@@ -227,7 +244,7 @@ public class OrderServiceTest {
     }
 
     /**
-     * 6. [추가 실패 케이스] 권한 없는 제3자의 접근 차단
+     * [추가 실패 케이스] 권한 없는 제3자의 접근 차단
      */
     @Test
     @DisplayName("[보안 실패] 주문 상세 조회 차단 - 본인이나 가게 사장님이 아닌 제3자가 조회 시 예외 발생")


### PR DESCRIPTION
<br/>

## ✨  제목 : Feat/#60 Order/Address 매 요청 시 DB 권한 재검증 및 테스트 코드 검증 완료 


<br/>

## 🔨 작업 내용

- validateUserRoleFromDB 메서드를 통한 실시간 DB 권한 대조 구현
- Address/Order 도메인: Controller/Service/Repository 전 계층 테스트 통과 (All Green)
  
<br/>

## 🍻  실행된 화면(postman에서 테스트한 것 캡쳐해서 올려주세요 성공, 예외처리되는것까지)

### Address Test
<img width="1006" height="399" alt="image" src="https://github.com/user-attachments/assets/bfebef0f-51fa-4245-8b69-01ae5626c17a" />
<img width="888" height="347" alt="image" src="https://github.com/user-attachments/assets/e535edce-7621-4115-a275-2ef629885c3f" />
<img width="1130" height="392" alt="image" src="https://github.com/user-attachments/assets/7eb55144-1526-4283-8ef7-963c142c2ffd" />

<br/>

### 배송지 생성 [고객A 토큰]
<img width="1656" height="1416" alt="image" src="https://github.com/user-attachments/assets/7013bb5f-a38a-40a5-b9d8-7041e61c7174" />

### 본인 목록 조회 [고객A 토큰]
<img width="1633" height="1447" alt="image" src="https://github.com/user-attachments/assets/7e3e9320-fc50-4d07-8538-9b49ea276f29" />

### 배송지 정보 수정 [고객A 토큰]
<img width="1642" height="1145" alt="image" src="https://github.com/user-attachments/assets/0b472c82-2798-4d90-b10d-7f9a3c45422e" />

<br/>

### Order Test
<img width="964" height="296" alt="image" src="https://github.com/user-attachments/assets/12159b8e-a674-4d55-91fd-24fdb4b9efe7" />
<img width="935" height="146" alt="image" src="https://github.com/user-attachments/assets/9b8bd614-824c-49b9-8256-62053326da37" />
<img width="1113" height="485" alt="image" src="https://github.com/user-attachments/assets/65f68890-8307-4be1-9e3f-1f7cb4ebeff8" />

<br/>

### 주문 생성 (성공) [고객A 토큰]
<img width="1631" height="1183" alt="image" src="https://github.com/user-attachments/assets/d6f6237f-369b-4db2-99c8-cd396a2f9ffd" />

### 주문 상태 순차 변경 (비즈니스 규칙) [사장B 토큰]
<img width="1640" height="1232" alt="image" src="https://github.com/user-attachments/assets/59dc6c5a-b614-4bad-9f14-287a4de1fedf" />

### 조리 중 요청사항 수정 시도 (상태 방어) [사장B 토큰]
<img width="1631" height="734" alt="image" src="https://github.com/user-attachments/assets/e2d2c511-1c7e-452c-91c9-7f0feef0ee73" />

### 주문 취소 (정상) [고객A 토큰]
<img width="1634" height="1308" alt="image" src="https://github.com/user-attachments/assets/b7f84634-0733-4a9a-8b80-449e153d1065" />


### 🎯 5분 취소 제한 (시간 초과 방어)
> Auth: 고객A 토큰 (이미 10분 전 주문임)
<img width="1628" height="725" alt="image" src="https://github.com/user-attachments/assets/b8077d3a-636e-4b42-b768-aa474262342a" />

### 🎯 사장님 권한 도용 차단
> Auth: 사장B 토큰 (이 주문은 사장D의 가게 주문임)
<img width="1618" height="729" alt="image" src="https://github.com/user-attachments/assets/4d8e1951-039d-441d-a08a-dba26b0ae996" />

### 🎯 페이징 사이즈 강제 제한
> 응답 JSON 하단의 size 필드가 10으로 강제 교정되었는지 확인
<img width="1605" height="1544" alt="image" src="https://github.com/user-attachments/assets/f0e89e57-22c2-4522-a7fc-5ab58dd17ff9" />

<br/>

## 🔎   앞으로의 과제

- 통합 테스트 

  <br/>

