### PR TITLE
Feat/#58: UserAuth, SearchTest

### DIFF
--- a/src/main/java/com/example/whostolemyfood/store/application/service/StoreSearchServiceV1.java
+++ b/src/main/java/com/example/whostolemyfood/store/application/service/StoreSearchServiceV1.java
@@ -1,14 +1,22 @@
 package com.example.whostolemyfood.store.application.service;
 
+import com.example.whostolemyfood.global.exception.CustomException;
+import com.example.whostolemyfood.global.exception.ErrorCode;
 import com.example.whostolemyfood.global.response.PageResponse;
 import com.example.whostolemyfood.store.domain.repository.StoreRepositoryCustom;
 import com.example.whostolemyfood.store.presentation.dto.request.StoreSearchConditionV1;
 import com.example.whostolemyfood.store.presentation.dto.response.StoreSearchResponseDtoV1;
+import com.example.whostolemyfood.user.domain.entity.UserEntity;
+import com.example.whostolemyfood.user.domain.entity.UserRole;
+import com.example.whostolemyfood.user.domain.repository.UserRepository;
+import com.example.whostolemyfood.user.domain.repository.UserRepositoryCustom;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -16,12 +24,40 @@ import org.springframework.transaction.annotation.Transactional;
 public class StoreSearchServiceV1 {
 
     private final StoreRepositoryCustom storeRepositoryCustom;
+    private final UserRepository userRepository;
 
-    public PageResponse<StoreSearchResponseDtoV1> search(StoreSearchConditionV1 condition, Pageable pageable) {
+    public PageResponse<StoreSearchResponseDtoV1> search(
+            StoreSearchConditionV1 condition,
+            Pageable pageable,
+            UUID userid,
+            String userRole
+    ) {
+
+        UserEntity loginUser = validateActiveUserAndRole(userid,userRole);
+
         // 1. 리포지토리에서 Page 객체 조회
         Page<StoreSearchResponseDtoV1> pageResult = storeRepositoryCustom.searchStore(condition, pageable);
 
         // 2. 공통 응답 객체인 PageResponse로 변환하여 반환
         return new PageResponse<>(pageResult);
     }
+
+    private UserEntity validateActiveUserAndRole(UUID loginUserId, String tokenRole) {
+        UserEntity user = userRepository.findById(loginUserId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        if (Boolean.TRUE.equals(user.getIsDeleted())) {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        String Role = user.getUserRole().name();
+        if (!Role.equals(tokenRole)) {
+            throw new CustomException(ErrorCode.ACCESS_DENIED);
+        }
+
+        return user;
+    }
+
+
+
 }

--- a/src/main/java/com/example/whostolemyfood/store/presentation/controller/StoreControllerV1.java
+++ b/src/main/java/com/example/whostolemyfood/store/presentation/controller/StoreControllerV1.java
@@ -99,13 +99,14 @@ public class StoreControllerV1 {
     @GetMapping("/search")
     public ResponseEntity<PageResponse<StoreSearchResponseDtoV1>> search(
             @ModelAttribute StoreSearchConditionV1 condition,
-            @PageableDefault(size = 10, page = 0) Pageable pageable
+            @PageableDefault(size = 10, page = 0) Pageable pageable,
+            @AuthenticationPrincipal AuthUser authUser
     ) {
         // 1. PageUtil을 사용하여 페이지 사이즈 검증 및 보정
         Pageable validatedPageable = PageUtil.validatePageSize(pageable);
 
         // 2. 서비스 호출 및 결과 반환
-        PageResponse<StoreSearchResponseDtoV1> response = storeSearchService.search(condition, validatedPageable);
+        PageResponse<StoreSearchResponseDtoV1> response = storeSearchService.search(condition, validatedPageable,authUser.getUserId(), authUser.role().name());
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/whostolemyfood/store/presentation/dto/request/StoreSearchConditionV1.java
+++ b/src/main/java/com/example/whostolemyfood/store/presentation/dto/request/StoreSearchConditionV1.java
@@ -21,4 +21,5 @@ public class StoreSearchConditionV1 {
     private String sortBy;     // 정렬 기준 (예: "createdAt", "rating")
 
     private Integer page = 0;
+    private Integer size = 10;
 }

--- a/src/test/java/com/example/whostolemyfood/store/StoreControllerTest.java
+++ b/src/test/java/com/example/whostolemyfood/store/StoreControllerTest.java
@@ -1,0 +1,638 @@
+package com.example.whostolemyfood.store;
+
+
+import com.example.whostolemyfood.global.config.security.jwt.JwtUtil;
+import com.example.whostolemyfood.global.response.PageResponse;
+import com.example.whostolemyfood.store.application.service.StoreSearchServiceV1;
+import com.example.whostolemyfood.store.application.service.StoreServiceV1;
+import com.example.whostolemyfood.store.presentation.controller.StoreControllerV1;
+import com.example.whostolemyfood.store.presentation.dto.request.StoreSearchConditionV1;
+import com.example.whostolemyfood.store.presentation.dto.response.StoreSearchResponseDtoV1;
+import com.example.whostolemyfood.user.application.security.AuthUser;
+import com.example.whostolemyfood.user.domain.entity.UserRole;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(StoreControllerV1.class)
+@AutoConfigureMockMvc
+@DisplayName("StoreControllerV1 - search 엔드포인트 테스트")
+class StoreControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private StoreSearchServiceV1 storeSearchService;
+
+    @MockitoBean
+    private JwtUtil jwtUtil;
+
+    @MockitoBean
+    private StoreServiceV1 storeService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private UUID testUserId;
+    private AuthUser testAuthUser;
+    private Authentication testAuthentication;
+    private StoreSearchConditionV1 searchCondition;
+    private Pageable pageable;
+
+    @BeforeEach
+    void setUp() {
+        testUserId = UUID.randomUUID();
+        // ✅ AuthUser record 생성
+        testAuthUser = new AuthUser(
+                testUserId,
+                "test@example.com",
+                UserRole.CUSTOMER
+        );
+
+        // ✅ Authentication 객체 생성 (testAuthUser를 principal로 사용)
+        testAuthentication = new UsernamePasswordAuthenticationToken(
+                testAuthUser,
+                null,
+                testAuthUser.getAuthorities()
+        );
+
+        searchCondition = new StoreSearchConditionV1();
+        searchCondition.setKeyword("짜장");
+        pageable = PageRequest.of(0, 10);
+    }
+
+    // ============ 정상 케이스 ============
+
+    @Test
+    @DisplayName("정상: 가게 검색 성공 - 결과 1개")
+    void search_Success() throws Exception {
+        // given
+        StoreSearchResponseDtoV1 mockStoreDto = StoreSearchResponseDtoV1.builder()
+                .storeId(UUID.randomUUID())
+                .storeName("짜장백개")
+                .build();
+
+        PageResponse<StoreSearchResponseDtoV1> mockResponse = new PageResponse<>(
+                new PageImpl<>(
+                        List.of(mockStoreDto),
+                        pageable,
+                        1
+                )
+        );
+
+        given(storeSearchService.search(
+                any(StoreSearchConditionV1.class),
+                any(Pageable.class),
+                eq(testAuthUser.getUserId()),
+                eq(testAuthUser.role().name())
+        )).willReturn(mockResponse);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/stores/search")
+                        .param("keyword", "짜장")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .with(authentication(testAuthentication))  // ✅ Authentication 객체 전달
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(1)))
+                .andExpect(jsonPath("$.content[0].storeName", equalTo("짜장백개")))
+                .andExpect(jsonPath("$.totalElements", equalTo(1)));
+
+        verify(storeSearchService, times(1)).search(
+                any(StoreSearchConditionV1.class),
+                any(Pageable.class),
+                any(UUID.class),
+                any(String.class)
+        );
+    }
+
+    @Test
+    @DisplayName("정상: 검색 결과가 없을 때")
+    void search_EmptyResult() throws Exception {
+        // given
+        PageResponse<StoreSearchResponseDtoV1> mockResponse = new PageResponse<>(
+                new PageImpl<>(
+                        Collections.emptyList(),
+                        pageable,
+                        0
+                )
+        );
+
+        given(storeSearchService.search(
+                any(StoreSearchConditionV1.class),
+                any(Pageable.class),
+                any(UUID.class),
+                any(String.class)
+        )).willReturn(mockResponse);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/stores/search")
+                        .param("keyword", "없는음식")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .with(authentication(testAuthentication))
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(0)))
+                .andExpect(jsonPath("$.totalElements", equalTo(0)));
+    }
+
+    @Test
+    @DisplayName("정상: 여러 개의 검색 결과 반환")
+    void search_MultipleResults() throws Exception {
+        // given
+        List<StoreSearchResponseDtoV1> mockStores = List.of(
+                StoreSearchResponseDtoV1.builder()
+                        .storeId(UUID.randomUUID())
+                        .storeName("짜장백개")
+                        .build(),
+                StoreSearchResponseDtoV1.builder()
+                        .storeId(UUID.randomUUID())
+                        .storeName("짜장이네")
+                        .build(),
+                StoreSearchResponseDtoV1.builder()
+                        .storeId(UUID.randomUUID())
+                        .storeName("짜장코리아")
+                        .build()
+        );
+
+        PageResponse<StoreSearchResponseDtoV1> mockResponse = new PageResponse<>(
+                new PageImpl<>(
+                        mockStores,
+                        pageable,
+                        3
+                )
+        );
+
+        given(storeSearchService.search(
+                any(StoreSearchConditionV1.class),
+                any(Pageable.class),
+                any(UUID.class),
+                any(String.class)
+        )).willReturn(mockResponse);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/stores/search")
+                        .param("keyword", "짜장")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .with(authentication(testAuthentication))
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(3)))
+                .andExpect(jsonPath("$.totalElements", equalTo(3)))
+                .andExpect(jsonPath("$.content[0].storeName", equalTo("짜장백개")))
+                .andExpect(jsonPath("$.content[1].storeName", equalTo("짜장이네")))
+                .andExpect(jsonPath("$.content[2].storeName", equalTo("짜장코리아")));
+    }
+
+    // ============ 페이징 테스트 ============
+
+    @Test
+    @DisplayName("정상: 페이징 - 첫 번째 페이지 (0번 페이지)")
+    void search_FirstPage() throws Exception {
+        // given
+        StoreSearchResponseDtoV1 mockStoreDto = StoreSearchResponseDtoV1.builder()
+                .storeId(UUID.randomUUID())
+                .storeName("짜장백개")
+                .build();
+
+        Pageable firstPageable = PageRequest.of(0, 10);
+        PageResponse<StoreSearchResponseDtoV1> mockResponse = new PageResponse<>(
+                new PageImpl<>(
+                        List.of(mockStoreDto),
+                        firstPageable,
+                        11
+                )
+        );
+
+        given(storeSearchService.search(
+                any(StoreSearchConditionV1.class),
+                any(Pageable.class),
+                any(UUID.class),
+                any(String.class)
+        )).willReturn(mockResponse);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/stores/search")
+                        .param("keyword", "짜장")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .with(authentication(testAuthentication))
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements", equalTo(11)))
+                .andExpect(jsonPath("$.content", hasSize(1)));
+    }
+
+    @Test
+    @DisplayName("정상: 페이징 - 두 번째 페이지 (1번 페이지)")
+    void search_SecondPage() throws Exception {
+        // given
+        StoreSearchResponseDtoV1 mockStoreDto = StoreSearchResponseDtoV1.builder()
+                .storeId(UUID.randomUUID())
+                .storeName("짜장이네")
+                .build();
+
+        Pageable secondPageable = PageRequest.of(1, 10);
+        PageResponse<StoreSearchResponseDtoV1> mockResponse = new PageResponse<>(
+                new PageImpl<>(
+                        List.of(mockStoreDto),
+                        secondPageable,
+                        11
+                )
+        );
+
+        given(storeSearchService.search(
+                any(StoreSearchConditionV1.class),
+                any(Pageable.class),
+                any(UUID.class),
+                any(String.class)
+        )).willReturn(mockResponse);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/stores/search")
+                        .param("keyword", "짜장")
+                        .param("page", "1")
+                        .param("size", "10")
+                        .with(authentication(testAuthentication))
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements", equalTo(11)))
+                .andExpect(jsonPath("$.content", hasSize(1)));
+    }
+
+    // ============ 파라미터 검증 테스트 ============
+
+    @Test
+    @DisplayName("정상: 파라미터 없이 검색 (기본값 사용)")
+    void search_WithoutKeyword() throws Exception {
+        // given
+        PageResponse<StoreSearchResponseDtoV1> mockResponse = new PageResponse<>(
+                new PageImpl<>(
+                        Collections.emptyList(),
+                        PageRequest.of(0, 10),
+                        0
+                )
+        );
+
+        given(storeSearchService.search(
+                any(StoreSearchConditionV1.class),
+                any(Pageable.class),
+                any(UUID.class),
+                any(String.class)
+        )).willReturn(mockResponse);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/stores/search")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .with(authentication(testAuthentication))
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(0)));
+    }
+
+    @Test
+    @DisplayName("정상: 커스텀 페이지 사이즈 (size=20)")
+    void search_CustomPageSize() throws Exception {
+        // given
+        List<StoreSearchResponseDtoV1> mockStores = List.of(
+                StoreSearchResponseDtoV1.builder()
+                        .storeId(UUID.randomUUID())
+                        .storeName("짜장백개")
+                        .build()
+        );
+
+        Pageable customPageable = PageRequest.of(0, 20);
+        PageResponse<StoreSearchResponseDtoV1> mockResponse = new PageResponse<>(
+                new PageImpl<>(
+                        mockStores,
+                        customPageable,
+                        1
+                )
+        );
+
+        given(storeSearchService.search(
+                any(StoreSearchConditionV1.class),
+                any(Pageable.class),
+                any(UUID.class),
+                any(String.class)
+        )).willReturn(mockResponse);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/stores/search")
+                        .param("keyword", "짜장")
+                        .param("page", "0")
+                        .param("size", "20")
+                        .with(authentication(testAuthentication))
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(1)));
+    }
+
+    // ============ 인증 관련 테스트 ============
+
+    @Test
+    @DisplayName("정상: CUSTOMER 역할로 검색")
+    void search_CustomerRole() throws Exception {
+        // given
+        PageResponse<StoreSearchResponseDtoV1> mockResponse = new PageResponse<>(
+                new PageImpl<>(
+                        Collections.emptyList(),
+                        pageable,
+                        0
+                )
+        );
+
+        given(storeSearchService.search(
+                any(StoreSearchConditionV1.class),
+                any(Pageable.class),
+                any(UUID.class),
+                eq(UserRole.CUSTOMER.name())
+        )).willReturn(mockResponse);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/stores/search")
+                        .param("keyword", "짜장")
+                        .with(authentication(testAuthentication))
+        );
+
+        // then
+        resultActions.andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("정상: MANAGER 역할로 검색")
+    void search_ManagerRole() throws Exception {
+        // given
+        AuthUser managerAuthUser = new AuthUser(
+                UUID.randomUUID(),
+                "manager@example.com",
+                UserRole.MANAGER
+        );
+
+        Authentication managerAuthentication = new UsernamePasswordAuthenticationToken(
+                managerAuthUser,
+                null,
+                managerAuthUser.getAuthorities()
+        );
+
+        PageResponse<StoreSearchResponseDtoV1> mockResponse = new PageResponse<>(
+                new PageImpl<>(
+                        Collections.emptyList(),
+                        pageable,
+                        0
+                )
+        );
+
+        given(storeSearchService.search(
+                any(StoreSearchConditionV1.class),
+                any(Pageable.class),
+                eq(managerAuthUser.getUserId()),
+                eq(UserRole.MANAGER.name())
+        )).willReturn(mockResponse);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/stores/search")
+                        .param("keyword", "짜장")
+                        .with(authentication(managerAuthentication))
+        );
+
+        // then
+        resultActions.andExpect(status().isOk());
+    }
+
+    // ============ 응답 구조 검증 ============
+
+    @Test
+    @DisplayName("정상: 응답 구조 전체 검증")
+    void search_ResponseStructure() throws Exception {
+        // given
+        UUID storeId = UUID.randomUUID();
+        StoreSearchResponseDtoV1 mockStoreDto = StoreSearchResponseDtoV1.builder()
+                .storeId(storeId)
+                .storeName("짜장백개")
+                .build();
+
+        PageResponse<StoreSearchResponseDtoV1> mockResponse = new PageResponse<>(
+                new PageImpl<>(
+                        List.of(mockStoreDto),
+                        pageable,
+                        1
+                )
+        );
+
+        given(storeSearchService.search(
+                any(StoreSearchConditionV1.class),
+                any(Pageable.class),
+                any(UUID.class),
+                any(String.class)
+        )).willReturn(mockResponse);
+
+        // when & then
+        mockMvc.perform(
+                        get("/api/stores/search")
+                                .param("keyword", "짜장")
+                                .with(authentication(testAuthentication))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", notNullValue()))
+                .andExpect(jsonPath("$.totalElements", notNullValue()))
+                .andExpect(jsonPath("$.totalPages", notNullValue()))
+                .andExpect(jsonPath("$.content[0].storeId", equalTo(storeId.toString())))
+                .andExpect(jsonPath("$.content[0].storeName", equalTo("짜장백개")));
+    }
+
+    // ============ 비정상 페이징 테스트 ============
+
+    @Test
+    @DisplayName("비정상: 과도한 page size (99999) - 조정됨")
+    void test_ExcessivePageSize() throws Exception {
+        // given
+        List<StoreSearchResponseDtoV1> mockStores = List.of(
+                StoreSearchResponseDtoV1.builder()
+                        .storeId(UUID.randomUUID())
+                        .storeName("짜장백개")
+                        .build()
+        );
+
+        Pageable adjustedPageable = PageRequest.of(0, 10);  // 조정된 사이즈
+        PageResponse<StoreSearchResponseDtoV1> mockResponse = new PageResponse<>(
+                new PageImpl<>(
+                        mockStores,
+                        adjustedPageable,
+                        1
+                )
+        );
+
+        given(storeSearchService.search(
+                any(StoreSearchConditionV1.class),
+                any(Pageable.class),
+                any(UUID.class),
+                any(String.class)
+        )).willReturn(mockResponse);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/stores/search")
+                        .param("keyword", "짜장")
+                        .param("page", "0")
+                        .param("size", "99999")  // 비정상적으로 큰 사이즈
+                        .with(authentication(testAuthentication))
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(1)))
+                .andExpect(jsonPath("$.size", equalTo(10)));
+    }
+
+    @Test
+    @DisplayName("비정상: 음수 page size - 기본값으로 조정됨")
+    void test_NegativePageSize() throws Exception {
+        // given
+        List<StoreSearchResponseDtoV1> mockStores = List.of(
+                StoreSearchResponseDtoV1.builder()
+                        .storeId(UUID.randomUUID())
+                        .storeName("짜장백개")
+                        .build()
+        );
+
+        // 음수 size는 기본값(10)으로 조정
+        Pageable defaultPageable = PageRequest.of(0, 10);
+        PageResponse<StoreSearchResponseDtoV1> mockResponse = new PageResponse<>(
+                new PageImpl<>(
+                        mockStores,
+                        defaultPageable,
+                        1
+                )
+        );
+
+        given(storeSearchService.search(
+                any(StoreSearchConditionV1.class),
+                any(Pageable.class),
+                any(UUID.class),
+                any(String.class)
+        )).willReturn(mockResponse);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/stores/search")
+                        .param("keyword", "짜장")
+                        .param("page", "0")
+                        .param("size", "-10")  // 음수 사이즈
+                        .with(authentication(testAuthentication))
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(1)))
+                .andExpect(jsonPath("$.size", equalTo(10)));
+    }
+
+
+    @Test
+    @DisplayName("비정상: size=0 - 기본값으로 조정됨")
+    void test_ZeroPageSize() throws Exception {
+        // given
+        List<StoreSearchResponseDtoV1> mockStores = List.of(
+                StoreSearchResponseDtoV1.builder()
+                        .storeId(UUID.randomUUID())
+                        .storeName("짜장백개")
+                        .build()
+        );
+
+        // size=0은 기본값(10)으로 조정
+        Pageable defaultPageable = PageRequest.of(0, 10);
+        PageResponse<StoreSearchResponseDtoV1> mockResponse = new PageResponse<>(
+                new PageImpl<>(
+                        mockStores,
+                        defaultPageable,
+                        1
+                )
+        );
+
+        given(storeSearchService.search(
+                any(StoreSearchConditionV1.class),
+                any(Pageable.class),
+                any(UUID.class),
+                any(String.class)
+        )).willReturn(mockResponse);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/stores/search")
+                        .param("keyword", "짜장")
+                        .param("page", "0")
+                        .param("size", "0")  // 0 사이즈
+                        .with(authentication(testAuthentication))
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(1)))
+                .andExpect(jsonPath("$.size", equalTo(10)));
+    }
+}

--- a/src/test/java/com/example/whostolemyfood/store/StoreRepositoryCustomImplTest.java
+++ b/src/test/java/com/example/whostolemyfood/store/StoreRepositoryCustomImplTest.java
@@ -1,0 +1,129 @@
+package com.example.whostolemyfood.store;
+
+import com.example.whostolemyfood.address.domain.entity.AddressEntity;
+import com.example.whostolemyfood.area.domain.entity.AreaEntity;
+import com.example.whostolemyfood.category.domain.entity.CategoryEntity;
+import com.example.whostolemyfood.global.config.JpaAuditingConfig;
+import com.example.whostolemyfood.global.config.search.QueryDSLConfig;
+import com.example.whostolemyfood.menu.domain.entity.MenuEntity;
+import com.example.whostolemyfood.store.domain.entity.StoreEntity;
+import com.example.whostolemyfood.store.domain.repository.StoreRepositoryCustom;
+import com.example.whostolemyfood.store.infrastructure.repository.StoreRepositoryCustomImpl;
+import com.example.whostolemyfood.store.presentation.dto.request.StoreSearchConditionV1;
+import com.example.whostolemyfood.store.presentation.dto.response.StoreSearchResponseDtoV1;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+//@JPATest 시 bean Context 문제 발생으로 SpringBootTest로 진행
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class StoreRepositoryCustomImplTest {
+
+    @Autowired
+    private StoreRepositoryCustom storeRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    @Test
+    @DisplayName("가게명 또는 메뉴명으로 검색 시 중복 없이 페이징 결과가 반환된다")
+    @Transactional
+    void searchStore_KeywordTest() {
+        // given: 가게 및 메뉴 세팅 (가게 1개에 메뉴 3개)
+        CategoryEntity category = CategoryEntity.builder()
+                .categoryId(UUID.randomUUID())
+                .name("중식")
+                .build();
+        em.persist(category);
+
+        AreaEntity area = AreaEntity.builder()
+                .ukName("대구_중구_성내동_01")
+                .city("대구")
+                .district("중구")
+                .isActive(true)
+                .build();
+        em.persist(area);
+
+        AddressEntity address = AddressEntity.builder()
+                .userId(UUID.randomUUID())
+                .address("광화문")
+                .isDefault(false)
+                .build();
+
+        StoreEntity store = StoreEntity.builder()
+                .name("짜장백개")
+                .address("대구 중구 종로 100")
+                .phone("053-123-4567")
+                .content("정통 중식 전문점")
+                .category(category)
+                .area(area)
+                .openTime(LocalTime.of(11, 0))
+                .closeTime(LocalTime.of(22, 0))
+                .minOrderPrice(10000)
+                .isDeleted(false)
+                .build();
+        em.persist(store);
+
+        em.persist(MenuEntity.builder()
+                .store(store)
+                .price(7000)
+                .isDeleted(false)
+                .name("짜장면")
+                .build());
+
+        em.persist(MenuEntity.builder()
+                .store(store)
+                .price(10000)
+                .isDeleted(false)
+                .name("짬뽕")
+                .build());
+
+        em.persist(MenuEntity.builder()
+                .store(store)
+                .price(20000)
+                .isDeleted(false)
+                .name("탕수육")
+                .build());
+
+        em.flush();
+        em.clear();
+
+        StoreSearchConditionV1 cond = new StoreSearchConditionV1();
+        cond.setKeyword("짜장"); // 가게명에도 있고 메뉴명에도 있음
+        PageRequest pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<StoreSearchResponseDtoV1> result = storeRepository.searchStore(cond, pageable);
+
+        // then
+        System.out.println("========== 검색 결과 ==========");
+        System.out.println("총 개수: " + result.getTotalElements());
+        System.out.println("현재 페이지 개수: " + result.getContent().size());
+        System.out.println("검색 결과:");
+        result.getContent().forEach(storeDto -> {
+            System.out.println("  - Store ID: " + storeDto.getStoreId());
+            System.out.println("    Store Name: " + storeDto.getStoreName());
+            System.out.println("    Matched Menu: " + storeDto.getStoreAddress());
+        });
+        System.out.println("==============================");
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getTotalElements()).isEqualTo(1);
+    }
+}

--- a/src/test/java/com/example/whostolemyfood/store/StoreServiceTest.java
+++ b/src/test/java/com/example/whostolemyfood/store/StoreServiceTest.java
@@ -1,0 +1,378 @@
+package com.example.whostolemyfood.store;
+
+import com.example.whostolemyfood.store.application.service.StoreSearchServiceV1;
+import org.junit.jupiter.api.Test;
+
+import com.example.whostolemyfood.global.exception.CustomException;
+import com.example.whostolemyfood.global.exception.ErrorCode;
+import com.example.whostolemyfood.global.response.PageResponse;
+import com.example.whostolemyfood.store.domain.repository.StoreRepositoryCustom;
+import com.example.whostolemyfood.store.presentation.dto.request.StoreSearchConditionV1;
+import com.example.whostolemyfood.store.presentation.dto.response.StoreSearchResponseDtoV1;
+import com.example.whostolemyfood.user.domain.entity.UserEntity;
+import com.example.whostolemyfood.user.domain.entity.UserRole;
+import com.example.whostolemyfood.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("StoreSearchServiceV1 테스트")
+class StoreServiceTest {
+
+    @Mock
+    private StoreRepositoryCustom storeRepositoryCustom;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private StoreSearchServiceV1 storeSearchServiceV1;
+
+    private UUID testUserId;
+    private UserEntity testUser;
+    private StoreSearchConditionV1 searchCondition;
+    private Pageable pageable;
+
+    @BeforeEach
+    void setUp() {
+        testUserId = UUID.randomUUID();
+        testUser = UserEntity.builder()
+                .email("test@example.com")
+                .name("테스트유저")
+                .role(UserRole.CUSTOMER)
+                .build();
+        ReflectionTestUtils.setField(testUser, "id", testUserId);
+
+        searchCondition = new StoreSearchConditionV1();
+        searchCondition.setKeyword("짜장");
+        pageable = PageRequest.of(0, 10);
+    }
+
+    // ============ 정상 케이스 ============
+
+    @Test
+    @DisplayName("정상: 가게 검색 성공")
+    void search_Success() {
+        // given
+        StoreSearchResponseDtoV1 mockStoreDto = StoreSearchResponseDtoV1.builder()
+                .storeId(UUID.randomUUID())
+                .storeName("짜장백개")
+                .build();
+
+        Page<StoreSearchResponseDtoV1> mockPage = new PageImpl<>(
+                List.of(mockStoreDto),
+                pageable,
+                1
+        );
+
+        given(userRepository.findById(testUserId))
+                .willReturn(Optional.of(testUser));
+        given(storeRepositoryCustom.searchStore(searchCondition, pageable))
+                .willReturn(mockPage);
+
+        // when
+        PageResponse<StoreSearchResponseDtoV1> result = storeSearchServiceV1.search(
+                searchCondition,
+                pageable,
+                testUserId,
+                UserRole.CUSTOMER.name()
+        );
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getStoreName()).isEqualTo("짜장백개");
+        assertThat(result.getTotalElements()).isEqualTo(1);
+
+        // verify: 메서드 호출 확인
+        verify(userRepository, times(1)).findById(testUserId);
+        verify(storeRepositoryCustom, times(1)).searchStore(searchCondition, pageable);
+    }
+
+    @Test
+    @DisplayName("정상: 검색 결과가 없을 때")
+    void search_EmptyResult() {
+        // given
+        Page<StoreSearchResponseDtoV1> emptyPage = new PageImpl<>(
+                Collections.emptyList(),
+                pageable,
+                0
+        );
+
+        given(userRepository.findById(testUserId))
+                .willReturn(Optional.of(testUser));
+        given(storeRepositoryCustom.searchStore(searchCondition, pageable))
+                .willReturn(emptyPage);
+
+        // when
+        PageResponse<StoreSearchResponseDtoV1> result = storeSearchServiceV1.search(
+                searchCondition,
+                pageable,
+                testUserId,
+                UserRole.CUSTOMER.name()
+        );
+
+        // then
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("정상: 여러 개의 검색 결과 반환")
+    void search_MultipleResults() {
+        // given
+        List<StoreSearchResponseDtoV1> mockStores = List.of(
+                StoreSearchResponseDtoV1.builder()
+                        .storeId(UUID.randomUUID())
+                        .storeName("짜장백개")
+                        .build(),
+                StoreSearchResponseDtoV1.builder()
+                        .storeId(UUID.randomUUID())
+                        .storeName("짜장이네")
+                        .build()
+        );
+
+        Page<StoreSearchResponseDtoV1> mockPage = new PageImpl<>(
+                mockStores,
+                pageable,
+                2
+        );
+
+        given(userRepository.findById(testUserId))
+                .willReturn(Optional.of(testUser));
+        given(storeRepositoryCustom.searchStore(searchCondition, pageable))
+                .willReturn(mockPage);
+
+        // when
+        PageResponse<StoreSearchResponseDtoV1> result = storeSearchServiceV1.search(
+                searchCondition,
+                pageable,
+                testUserId,
+                UserRole.CUSTOMER.name()
+        );
+
+        // then
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getTotalElements()).isEqualTo(2);
+    }
+
+    // ============ 예외 케이스 ============
+
+    @Test
+    @DisplayName("예외: 사용자를 찾을 수 없음")
+    void search_UserNotFound() {
+        // given
+        UUID nonExistentUserId = UUID.randomUUID();
+        given(userRepository.findById(nonExistentUserId))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> storeSearchServiceV1.search(
+                searchCondition,
+                pageable,
+                nonExistentUserId,
+                UserRole.CUSTOMER.name()
+        ))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+
+        verify(userRepository, times(1)).findById(nonExistentUserId);
+        verify(storeRepositoryCustom, times(0)).searchStore(any(), any());
+    }
+
+    @Test
+    @DisplayName("예외: 삭제된 사용자")
+    void search_DeletedUser() {
+        // given
+        UUID userId = UUID.randomUUID();
+        UserEntity deletedUser = UserEntity.builder()
+                .email("deleted@example.com")
+                .name("삭제된유저")
+                .role(UserRole.CUSTOMER)
+                .build();
+        deletedUser.softDelete();
+        ReflectionTestUtils.setField(deletedUser, "id", userId);
+
+        given(userRepository.findById(testUserId))
+                .willReturn(Optional.of(deletedUser));
+
+        // when & then
+        assertThatThrownBy(() -> storeSearchServiceV1.search(
+                searchCondition,
+                pageable,
+                testUserId,
+                UserRole.CUSTOMER.name()
+        ))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+
+        verify(storeRepositoryCustom, times(0)).searchStore(any(), any());
+    }
+
+    @Test
+    @DisplayName("예외: 역할(Role)이 일치하지 않음")
+    void search_RoleMismatch() {
+        // given
+        String differentRole = "MANAGER";  // 사용자는 USER인데 ADMIN으로 시도
+        given(userRepository.findById(testUserId))
+                .willReturn(Optional.of(testUser));
+
+        // when & then
+        assertThatThrownBy(() -> storeSearchServiceV1.search(
+                searchCondition,
+                pageable,
+                testUserId,
+                differentRole
+        ))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ACCESS_DENIED);
+
+        verify(storeRepositoryCustom, times(0)).searchStore(any(), any());
+    }
+
+    @Test
+    @DisplayName("예외: 잘못된 역할 형식")
+    void search_InvalidRoleFormat() {
+        // given
+        String invalidRole = "INVALID_ROLE";
+        given(userRepository.findById(testUserId))
+                .willReturn(Optional.of(testUser));
+
+        // when & then
+        assertThatThrownBy(() -> storeSearchServiceV1.search(
+                searchCondition,
+                pageable,
+                testUserId,
+                invalidRole
+        ))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ACCESS_DENIED);
+    }
+
+    // ============ 엣지 케이스 ============
+
+    @Test
+    @DisplayName("엣지: null 키워드로 검색")
+    void search_NullKeyword() {
+        // given
+        StoreSearchConditionV1 nullKeywordCondition = new StoreSearchConditionV1();
+        nullKeywordCondition.setKeyword(null);
+
+        Page<StoreSearchResponseDtoV1> mockPage = new PageImpl<>(
+                Collections.emptyList(),
+                pageable,
+                0
+        );
+
+        given(userRepository.findById(testUserId))
+                .willReturn(Optional.of(testUser));
+        given(storeRepositoryCustom.searchStore(nullKeywordCondition, pageable))
+                .willReturn(mockPage);
+
+        // when
+        PageResponse<StoreSearchResponseDtoV1> result = storeSearchServiceV1.search(
+                nullKeywordCondition,
+                pageable,
+                testUserId,
+                UserRole.CUSTOMER.name()
+        );
+
+        // then
+        assertThat(result.getContent()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("엣지: 페이징 처리 (페이지 2)")
+    void search_SecondPage() {
+        // given
+        Pageable secondPageable = PageRequest.of(1, 10);  // 두 번째 페이지
+
+        List<StoreSearchResponseDtoV1> mockStores = List.of(
+                StoreSearchResponseDtoV1.builder()
+                        .storeId(UUID.randomUUID())
+                        .storeName("짜장코리아")
+                        .build()
+        );
+
+        Page<StoreSearchResponseDtoV1> mockPage = new PageImpl<>(
+                mockStores,
+                secondPageable,
+                11  // 총 11개 항목
+        );
+
+        given(userRepository.findById(testUserId))
+                .willReturn(Optional.of(testUser));
+        given(storeRepositoryCustom.searchStore(searchCondition, secondPageable))
+                .willReturn(mockPage);
+
+        // when
+        PageResponse<StoreSearchResponseDtoV1> result = storeSearchServiceV1.search(
+                searchCondition,
+                secondPageable,
+                testUserId,
+                UserRole.CUSTOMER.name()
+        );
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getTotalElements()).isEqualTo(11);
+    }
+
+    @Test
+    @DisplayName("엣지: MANAGER 역할로 검색")
+    void search_AdminRole() {
+        // given
+        UUID adminId = UUID.randomUUID();
+        UserEntity adminUser = UserEntity.builder()
+                .email("admin@example.com")
+                .name("관리자")
+                .role(UserRole.MANAGER)
+                .build();
+
+        ReflectionTestUtils.setField(adminUser, "id", adminId);
+
+        Page<StoreSearchResponseDtoV1> mockPage = new PageImpl<>(
+                Collections.emptyList(),
+                pageable,
+                0
+        );
+
+        given(userRepository.findById(testUserId))
+                .willReturn(Optional.of(adminUser));
+        given(storeRepositoryCustom.searchStore(searchCondition, pageable))
+                .willReturn(mockPage);
+
+        // when
+        PageResponse<StoreSearchResponseDtoV1> result = storeSearchServiceV1.search(
+                searchCondition,
+                pageable,
+                testUserId,
+                UserRole.MANAGER.name()
+        );
+
+        // then
+        assertThat(result).isNotNull();
+        verify(storeRepositoryCustom, times(1)).searchStore(searchCondition, pageable);
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,49 @@
+spring:
+  application:
+    name: Backend
+
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: ${DB_TEST_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+
+  jpa:
+    database: postgresql
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    generate-ddl: true
+    hibernate:
+      ddl-auto: update
+    show_sql: true
+    open-in-view: false
+    properties:
+      hibernate:
+        format_sql: true
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+
+jwt:
+  secret: ${JWT_SECRET}
+  token:
+    access:
+      minute: ${JWT_ACCESS_MINUTE}
+    refresh:
+      minute: ${JWT_REFRESH_MINUTE}
+
+auth:
+  admin-token: ${ADMIN_SIGNUP_TOKEN}
+
+gemini:
+  api-key: ${AI_API_KEY}
+  base-url: ${BASE_URL}
+  model: ${MODEL}
+
+payment:
+  key: ${PAYMENT_KEY}


### PR DESCRIPTION
- service단 토큰 조작 검증
- Search repository
- Search service
- search controller 테스트 코드 작성


## 🔨 작업 내용

- Search Service 단에서 user 토큰 검증

- Search repository, service, controller unit test


  
<br/>

## 🍻  실행된 화면
- Search repository
@JPAtest 로 구현시 CustomRepository가 import 되지 않는 이슈가 발생 -> @SpringbootTest로 구현
<img width="487" height="88" alt="스크린샷 2026-04-28 오전 2 12 14" src="https://github.com/user-attachments/assets/d07e239c-f810-43e0-9f3e-90164bbfcf7d" />

- Search Service
<img width="482" height="288" alt="스크린샷 2026-04-28 오전 2 12 23" src="https://github.com/user-attachments/assets/26374798-ec67-4cb6-944a-a50a1ad90b12" />

- Search Controller
<img width="477" height="351" alt="스크린샷 2026-04-28 오전 2 11 40" src="https://github.com/user-attachments/assets/a825b95d-b2cf-43f3-bde6-799671e55733" />



<br/>

## 🔎   트러블 슈팅
- RepositoryTest에서 @JPAtest 로 구현시 CustomRepository가 import 되지 않는 이슈가 발생 -> @SpringbootTest로 구현



  <br/>

