### PR TITLE
Refactor&Test/#56 category authorization unit test

### DIFF
--- a/src/main/java/com/example/whostolemyfood/category/application/service/CategoryServiceV1.java
+++ b/src/main/java/com/example/whostolemyfood/category/application/service/CategoryServiceV1.java
@@ -34,9 +34,9 @@ public class CategoryServiceV1 {
         }
         CategoryEntity categoryEntity=CategoryEntity
                 .builder()
-                .categoryId(UUID.randomUUID())
                 .name(reqCategoryDto.getName())
                 .build();
+
         categoryEntity.markCreatedBy(loginUser.getId());
         categoryEntity=categoryRepository.save(categoryEntity);
         return ResGetCategoryDtoV1.from(categoryEntity);
@@ -45,14 +45,17 @@ public class CategoryServiceV1 {
     /**
      * 상세 카테고리 조회
      */
-    public ResGetCategoryDtoV1 getCategory(UUID id) {
+    public ResGetCategoryDtoV1 getCategory(UUID id,UUID userId,String Role) {
+        UserEntity loginUser = validateActiveUserAndRole(userId, Role);
         return ResGetCategoryDtoV1.from(getCategoryById(id));
     }
 
     /**
      * 카테고리 목록 조회
      */
-    public List<ResGetCategoryDtoV1> getCategories() {
+    public List<ResGetCategoryDtoV1> getCategories(UUID userId,String Role) {
+        UserEntity loginUser = validateActiveUserAndRole(userId, Role);
+
         return categoryRepository.findAll().stream()
                 .filter(category -> !category.getIsDeleted())
                 .map(ResGetCategoryDtoV1::from) // Entity를 DTO로 변환

--- a/src/main/java/com/example/whostolemyfood/category/application/service/CategoryServiceV1.java
+++ b/src/main/java/com/example/whostolemyfood/category/application/service/CategoryServiceV1.java
@@ -6,10 +6,13 @@ import com.example.whostolemyfood.category.presentation.dto.request.ReqCategoryD
 import com.example.whostolemyfood.category.presentation.dto.response.ResGetCategoryDtoV1;
 import com.example.whostolemyfood.global.exception.CustomException;
 import com.example.whostolemyfood.global.exception.ErrorCode;
+import com.example.whostolemyfood.global.response.PageResponse;
 import com.example.whostolemyfood.user.domain.entity.UserEntity;
 import com.example.whostolemyfood.user.domain.entity.UserRole;
 import com.example.whostolemyfood.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -53,13 +56,13 @@ public class CategoryServiceV1 {
     /**
      * 카테고리 목록 조회
      */
-    public List<ResGetCategoryDtoV1> getCategories(UUID userId,String Role) {
+    public PageResponse<ResGetCategoryDtoV1> getCategories(UUID userId, String Role, Pageable pageable) {
         UserEntity loginUser = validateActiveUserAndRole(userId, Role);
+        Page<CategoryEntity> categoryPage = categoryRepository.findByIsDeletedFalse(pageable);
 
-        return categoryRepository.findAll().stream()
-                .filter(category -> !category.getIsDeleted())
-                .map(ResGetCategoryDtoV1::from) // Entity를 DTO로 변환
-                .toList();
+        return new PageResponse<>(
+                categoryPage.map(ResGetCategoryDtoV1::from)
+        );
     }
 
     /**

--- a/src/main/java/com/example/whostolemyfood/category/domain/entity/CategoryEntity.java
+++ b/src/main/java/com/example/whostolemyfood/category/domain/entity/CategoryEntity.java
@@ -3,10 +3,8 @@ package com.example.whostolemyfood.category.domain.entity;
 
 import com.example.whostolemyfood.global.entity.BaseAuditEntity;
 import com.example.whostolemyfood.global.entity.BaseSoftDeleteEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,29 +13,28 @@ import java.util.UUID;
 
 @Entity
 @Table(name = "p_categories")
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+
 public class CategoryEntity extends BaseAuditEntity {
 
     // 카테고리 id
     @Id
     @Column(name="category_id")
+    @GeneratedValue(strategy = GenerationType.UUID)
     private UUID categoryId;
 
     // 카테고리 명
-    @Column(name="name",unique = true)
+    @Column(name="name")
     private String name;
 
     @Builder
-    public CategoryEntity(UUID categoryId, String name) {
-        this.categoryId = categoryId;
+    public CategoryEntity(String name) {
         this.name = name;
     }
 
     public void updateName(String name) {
         this.name = name;
     }
-
-
 
 }

--- a/src/main/java/com/example/whostolemyfood/category/domain/repository/CategoryRepository.java
+++ b/src/main/java/com/example/whostolemyfood/category/domain/repository/CategoryRepository.java
@@ -1,6 +1,8 @@
 package com.example.whostolemyfood.category.domain.repository;
 
 import com.example.whostolemyfood.category.domain.entity.CategoryEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.query.Param; // 추가
 
@@ -9,6 +11,8 @@ import java.util.UUID;
 
 // 1. Long -> UUID로 변경 (Entity의 @Id 타입과 일치시켜야 함)
 public interface CategoryRepository extends JpaRepository<CategoryEntity, UUID> {
+
+    Page<CategoryEntity> findByIsDeletedFalse(Pageable pageable);
 
     // 2. @Param 어노테이션 추가로 파라미터 명시
     Optional<CategoryEntity> findByCategoryIdAndIsDeletedFalse(@Param("categoryId") UUID categoryId);

--- a/src/main/java/com/example/whostolemyfood/category/presentation/controller/CategoryControllerV1.java
+++ b/src/main/java/com/example/whostolemyfood/category/presentation/controller/CategoryControllerV1.java
@@ -22,13 +22,18 @@ public class CategoryControllerV1 {
     private final CategoryServiceV1 categoryService;
 
     @GetMapping()
-    public ResponseEntity<List<ResGetCategoryDtoV1>> getCategories() {
-        return ResponseEntity.ok(categoryService.getCategories());
+    public ResponseEntity<List<ResGetCategoryDtoV1>> getCategories(
+            @AuthenticationPrincipal AuthUser loginUser
+    ) {
+        return ResponseEntity.ok(categoryService.getCategories(loginUser.getUserId(),loginUser.role().name()));
     }
 
     @GetMapping("/{category_id}")
-    public ResponseEntity<ResGetCategoryDtoV1> getCategory(@PathVariable("category_id") UUID categoryId) {
-        return ResponseEntity.ok(categoryService.getCategory(categoryId));
+    public ResponseEntity<ResGetCategoryDtoV1> getCategory(
+            @PathVariable("category_id") UUID categoryId,
+            @AuthenticationPrincipal AuthUser loginUser
+    ) {
+        return ResponseEntity.ok(categoryService.getCategory(categoryId,loginUser.getUserId(),loginUser.role().name()));
     }
 
     @PostMapping()

--- a/src/main/java/com/example/whostolemyfood/category/presentation/controller/CategoryControllerV1.java
+++ b/src/main/java/com/example/whostolemyfood/category/presentation/controller/CategoryControllerV1.java
@@ -3,9 +3,13 @@ package com.example.whostolemyfood.category.presentation.controller;
 import com.example.whostolemyfood.category.application.service.CategoryServiceV1;
 import com.example.whostolemyfood.category.presentation.dto.request.ReqCategoryDtoV1;
 import com.example.whostolemyfood.category.presentation.dto.response.ResGetCategoryDtoV1;
+import com.example.whostolemyfood.global.response.PageResponse;
 import com.example.whostolemyfood.user.application.security.AuthUser;
+import com.example.whostolemyfood.global.util.PageUtil;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -22,10 +26,14 @@ public class CategoryControllerV1 {
     private final CategoryServiceV1 categoryService;
 
     @GetMapping()
-    public ResponseEntity<List<ResGetCategoryDtoV1>> getCategories(
-            @AuthenticationPrincipal AuthUser loginUser
+    public ResponseEntity<PageResponse<ResGetCategoryDtoV1>> getCategories(
+            @AuthenticationPrincipal AuthUser loginUser,
+            @PageableDefault(size = 10, page = 0) Pageable pageable
     ) {
-        return ResponseEntity.ok(categoryService.getCategories(loginUser.getUserId(),loginUser.role().name()));
+
+        Pageable validatedPageable = PageUtil.validatePageSize(pageable);
+
+        return ResponseEntity.ok(categoryService.getCategories(loginUser.getUserId(),loginUser.role().name(),validatedPageable));
     }
 
     @GetMapping("/{category_id}")

--- a/src/test/java/com/example/whostolemyfood/category/CategoryControllerV1Test.java
+++ b/src/test/java/com/example/whostolemyfood/category/CategoryControllerV1Test.java
@@ -1,15 +1,13 @@
 package com.example.whostolemyfood.category;
 
-
 import com.example.whostolemyfood.category.application.service.CategoryServiceV1;
-import com.example.whostolemyfood.category.domain.repository.CategoryRepository;
 import com.example.whostolemyfood.category.presentation.controller.CategoryControllerV1;
 import com.example.whostolemyfood.category.presentation.dto.request.ReqCategoryDtoV1;
 import com.example.whostolemyfood.category.presentation.dto.response.ResGetCategoryDtoV1;
 import com.example.whostolemyfood.global.config.security.jwt.JwtUtil;
+import com.example.whostolemyfood.global.response.PageResponse;
 import com.example.whostolemyfood.user.application.security.AuthUser;
 import com.example.whostolemyfood.user.domain.entity.UserRole;
-import com.example.whostolemyfood.user.domain.repository.UserRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -17,13 +15,16 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -31,16 +32,17 @@ import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(CategoryControllerV1.class)
-@AutoConfigureMockMvc
-@DisplayName("CategoryControllerV1 테스트")
+@DisplayName("Category Controller 단위 테스트 (Pageable 적용)")
 class CategoryControllerV1Test {
 
     @Autowired
@@ -48,12 +50,6 @@ class CategoryControllerV1Test {
 
     @MockitoBean
     private CategoryServiceV1 categoryService;
-
-    @MockitoBean
-    private CategoryRepository categoryRepository;
-
-    @MockitoBean
-    private UserRepository userRepository;
 
     @MockitoBean
     private JwtUtil jwtUtil;
@@ -72,28 +68,25 @@ class CategoryControllerV1Test {
         testUserId = UUID.randomUUID();
         testCategoryId = UUID.randomUUID();
 
-        // ✅ AuthUser 생성 (MANAGER 역할)
         testAuthUser = new AuthUser(
                 testUserId,
                 "manager@example.com",
                 UserRole.MANAGER
         );
 
-        // ✅ Authentication 생성
         testAuthentication = new UsernamePasswordAuthenticationToken(
                 testAuthUser,
                 null,
                 testAuthUser.getAuthorities()
         );
 
-
         categoryRequest = new ReqCategoryDtoV1("한식");
     }
 
-    // ============ GET /api/v1/categories ============
+    // ============ GET /api/v1/categories (페이징 적용) ============
 
     @Test
-    @DisplayName("정상: 카테고리 목록 조회")
+    @DisplayName("정상: 카테고리 목록 조회 - 페이징 적용")
     void getCategories_Success() throws Exception {
         // given
         List<ResGetCategoryDtoV1> mockCategories = List.of(
@@ -111,10 +104,20 @@ class CategoryControllerV1Test {
                         .build()
         );
 
+        Pageable pageable = PageRequest.of(0, 10);
+        PageResponse<ResGetCategoryDtoV1> mockResponse = new PageResponse<>(
+                new PageImpl<>(
+                        mockCategories,
+                        pageable,
+                        3
+                )
+        );
+
         given(categoryService.getCategories(
                 eq(testAuthUser.getUserId()),
-                eq(testAuthUser.role().name())
-        )).willReturn(mockCategories);
+                eq(testAuthUser.role().name()),
+                any(Pageable.class)
+        )).willReturn(mockResponse);
 
         // when
         ResultActions resultActions = mockMvc.perform(
@@ -125,14 +128,17 @@ class CategoryControllerV1Test {
         // then
         resultActions
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$", hasSize(3)))
-                .andExpect(jsonPath("$[0].name", equalTo("한식")))
-                .andExpect(jsonPath("$[1].name", equalTo("일식")))
-                .andExpect(jsonPath("$[2].name", equalTo("중식")));
+                .andExpect(jsonPath("$.content", hasSize(3)))
+                .andExpect(jsonPath("$.content[0].name", equalTo("한식")))
+                .andExpect(jsonPath("$.content[1].name", equalTo("일식")))
+                .andExpect(jsonPath("$.content[2].name", equalTo("중식")))
+                .andExpect(jsonPath("$.totalElements", equalTo(3)))
+                .andExpect(jsonPath("$.totalPages", equalTo(1)));
 
         verify(categoryService, times(1)).getCategories(
                 eq(testAuthUser.getUserId()),
-                eq(testAuthUser.role().name())
+                eq(testAuthUser.role().name()),
+                any(Pageable.class)
         );
     }
 
@@ -140,10 +146,20 @@ class CategoryControllerV1Test {
     @DisplayName("정상: 카테고리 목록 조회 - 빈 결과")
     void getCategories_Empty() throws Exception {
         // given
+        Pageable pageable = PageRequest.of(0, 10);
+        PageResponse<ResGetCategoryDtoV1> mockResponse = new PageResponse<>(
+                new PageImpl<>(
+                        Collections.emptyList(),
+                        pageable,
+                        0
+                )
+        );
+
         given(categoryService.getCategories(
                 eq(testAuthUser.getUserId()),
-                eq(testAuthUser.role().name())
-        )).willReturn(List.of());
+                eq(testAuthUser.role().name()),
+                any(Pageable.class)
+        )).willReturn(mockResponse);
 
         // when
         ResultActions resultActions = mockMvc.perform(
@@ -154,7 +170,201 @@ class CategoryControllerV1Test {
         // then
         resultActions
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$", hasSize(0)));
+                .andExpect(jsonPath("$.content", hasSize(0)))
+                .andExpect(jsonPath("$.totalElements", equalTo(0)))
+                .andExpect(jsonPath("$.totalPages", equalTo(0)));
+    }
+
+    @Test
+    @DisplayName("정상: 카테고리 목록 조회 - page 파라미터")
+    void getCategories_WithPageParameter() throws Exception {
+        // given
+        List<ResGetCategoryDtoV1> mockCategories = List.of(
+                ResGetCategoryDtoV1.builder()
+                        .categoryId(UUID.randomUUID())
+                        .name("프랑스")
+                        .build(),
+                ResGetCategoryDtoV1.builder()
+                        .categoryId(UUID.randomUUID())
+                        .name("스페인")
+                        .build()
+        );
+
+        Pageable pageable = PageRequest.of(1, 10);
+        PageResponse<ResGetCategoryDtoV1> mockResponse = new PageResponse<>(
+                new PageImpl<>(
+                        mockCategories,
+                        pageable,
+                        22  // 총 22개 중 1번 페이지
+                )
+        );
+
+        given(categoryService.getCategories(
+                eq(testAuthUser.getUserId()),
+                eq(testAuthUser.role().name()),
+                any(Pageable.class)
+        )).willReturn(mockResponse);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/v1/categories")
+                        .param("page", "1")
+                        .param("size", "10")
+                        .with(authentication(testAuthentication))
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(2)))
+                .andExpect(jsonPath("$.totalElements", equalTo(22)))
+                .andExpect(jsonPath("$.totalPages", equalTo(3)));
+    }
+
+    @Test
+    @DisplayName("정상: 카테고리 목록 조회 - size 파라미터")
+    void getCategories_WithSizeParameter() throws Exception {
+        // given
+        List<ResGetCategoryDtoV1> mockCategories = List.of(
+                ResGetCategoryDtoV1.builder()
+                        .categoryId(UUID.randomUUID())
+                        .name("한식")
+                        .build()
+        );
+
+        Pageable pageable = PageRequest.of(0, 20);
+        PageResponse<ResGetCategoryDtoV1> mockResponse = new PageResponse<>(
+                new PageImpl<>(
+                        mockCategories,
+                        pageable,
+                        1
+                )
+        );
+
+        given(categoryService.getCategories(
+                eq(testAuthUser.getUserId()),
+                eq(testAuthUser.role().name()),
+                any(Pageable.class)
+        )).willReturn(mockResponse);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/v1/categories")
+                        .param("size", "20")
+                        .with(authentication(testAuthentication))
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(1)));
+    }
+
+    @Test
+    @DisplayName("정상: 카테고리 목록 조회 - sort 파라미터")
+    void getCategories_WithSortParameter() throws Exception {
+        // given
+        List<ResGetCategoryDtoV1> mockCategories = List.of(
+                ResGetCategoryDtoV1.builder()
+                        .categoryId(UUID.randomUUID())
+                        .name("중식")
+                        .build(),
+                ResGetCategoryDtoV1.builder()
+                        .categoryId(UUID.randomUUID())
+                        .name("일식")
+                        .build(),
+                ResGetCategoryDtoV1.builder()
+                        .categoryId(UUID.randomUUID())
+                        .name("한식")
+                        .build()
+        );
+
+        Pageable pageable = PageRequest.of(0, 10);
+        PageResponse<ResGetCategoryDtoV1> mockResponse = new PageResponse<>(
+                new PageImpl<>(
+                        mockCategories,
+                        pageable,
+                        3
+                )
+        );
+
+        given(categoryService.getCategories(
+                eq(testAuthUser.getUserId()),
+                eq(testAuthUser.role().name()),
+                any(Pageable.class)
+        )).willReturn(mockResponse);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/v1/categories")
+                        .param("sort", "name,desc")
+                        .with(authentication(testAuthentication))
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(3)))
+                .andExpect(jsonPath("$.content[0].name", equalTo("중식")));
+    }
+
+    @Test
+    @DisplayName("정상: 카테고리 목록 조회 - 페이징 복합 파라미터")
+    void getCategories_WithComplexParameters() throws Exception {
+        // given
+        List<ResGetCategoryDtoV1> mockCategories = List.of(
+                ResGetCategoryDtoV1.builder()
+                        .categoryId(UUID.randomUUID())
+                        .name("한식")
+                        .build(),
+                ResGetCategoryDtoV1.builder()
+                        .categoryId(UUID.randomUUID())
+                        .name("일식")
+                        .build(),
+                ResGetCategoryDtoV1.builder()
+                        .categoryId(UUID.randomUUID())
+                        .name("중식")
+                        .build(),
+                ResGetCategoryDtoV1.builder()
+                        .categoryId(UUID.randomUUID())
+                        .name("태국식")
+                        .build(),
+                ResGetCategoryDtoV1.builder()
+                        .categoryId(UUID.randomUUID())
+                        .name("인도식")
+                        .build()
+        );
+
+        Pageable pageable = PageRequest.of(0, 5);
+        PageResponse<ResGetCategoryDtoV1> mockResponse = new PageResponse<>(
+                new PageImpl<>(
+                        mockCategories,
+                        pageable,
+                        15  // 총 15개 중 첫 5개
+                )
+        );
+
+        given(categoryService.getCategories(
+                eq(testAuthUser.getUserId()),
+                eq(testAuthUser.role().name()),
+                any(Pageable.class)
+        )).willReturn(mockResponse);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/v1/categories")
+                        .param("page", "0")
+                        .param("size", "5")
+                        .param("sort", "createdAt,desc")
+                        .with(authentication(testAuthentication))
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(5)))
+                .andExpect(jsonPath("$.totalElements", equalTo(15)))
+                .andExpect(jsonPath("$.totalPages", equalTo(3)));
     }
 
     // ============ GET /api/v1/categories/{category_id} ============
@@ -193,163 +403,50 @@ class CategoryControllerV1Test {
         );
     }
 
-    @Test
-    @DisplayName("예외: 존재하지 않는 카테고리 조회")
-    void getCategory_NotFound() throws Exception {
-        // given
-        UUID nonExistentId = UUID.randomUUID();
-        given(categoryService.getCategory(
-                eq(nonExistentId),
-                eq(testAuthUser.getUserId()),
-                eq(testAuthUser.role().name())
-        )).willThrow(new IllegalArgumentException("존재하지 않는 카테고리입니다."));
-
-        // when
-        ResultActions resultActions = mockMvc.perform(
-                get("/api/v1/categories/{category_id}", nonExistentId)
-                        .with(authentication(testAuthentication))
-        );
-
-        // then
-        resultActions.andExpect(status().is4xxClientError());
-    }
-
     // ============ POST /api/v1/categories ============
 
     @Test
-    @DisplayName("정상: 카테고리 생성 - MANAGER 역할")
+    @DisplayName("정상: 카테고리 생성 성공")
     void createCategory_Success() throws Exception {
+
+        AuthUser managerAuthUser = new AuthUser(
+                UUID.randomUUID(),
+                "manager@example.com",
+                UserRole.MANAGER
+        );
+
+        Authentication managerAuthentication = new UsernamePasswordAuthenticationToken(
+                managerAuthUser,
+                null,
+                managerAuthUser.getAuthorities()
+        );
         // given
         ResGetCategoryDtoV1 mockResponse = ResGetCategoryDtoV1.builder()
                 .categoryId(testCategoryId)
                 .name("한식")
                 .build();
 
-
         given(categoryService.createCategory(
-                any(),  // ReqCategoryDtoV1
-                any(),  // userId
-                any()   // role
-        )).willReturn(mockResponse);
-
-        // when & then
-        mockMvc.perform(
-                        post("/api/v1/categories")
-                                .with(csrf())
-                                .with(authentication(testAuthentication))
-                                .contentType("application/json")
-                                .content(objectMapper.writeValueAsString(categoryRequest))
-                )
-                .andExpect(status().isCreated());
-    }
-
-    @Test
-    @DisplayName("정상: 카테고리 생성 - MASTER 역할")
-    void createCategory_MasterRole() throws Exception {
-        // given
-        AuthUser masterAuthUser = new AuthUser(
-                UUID.randomUUID(),
-                "master@example.com",
-                UserRole.MASTER
-        );
-
-        Authentication masterAuthentication = new UsernamePasswordAuthenticationToken(
-                masterAuthUser,
-                null,
-                masterAuthUser.getAuthorities()
-        );
-
-        ResGetCategoryDtoV1 mockResponse = ResGetCategoryDtoV1.builder()
-                .categoryId(testCategoryId)
-                .name("한식")
-                .build();
-
-        given(categoryService.createCategory(
-                any(ReqCategoryDtoV1.class),
-                any(UUID.class),  // ← any() 사용 (UUID 검증 안함)
-                any(String.class)  // ← any() 사용 (Role 문자열 검증 안함)
+                any(),
+                eq(managerAuthUser.userId()),
+                eq(UserRole.MANAGER.name())
         )).willReturn(mockResponse);
 
         // when
         ResultActions resultActions = mockMvc.perform(
                 post("/api/v1/categories")
                         .with(csrf())
-                        .with(authentication(masterAuthentication))
+                        .with(authentication(managerAuthentication))
                         .contentType("application/json")
                         .content(objectMapper.writeValueAsString(categoryRequest))
         );
 
         // then
-        resultActions.andExpect(status().isCreated());
-    }
-
-    @Test
-    @DisplayName("예외: 카테고리 생성 - CUSTOMER 역할 (권한 없음)")
-    void createCategory_CustomerRole_Forbidden() throws Exception {
-        // given
-        AuthUser customerAuthUser = new AuthUser(
-                UUID.randomUUID(),
-                "customer@example.com",
-                UserRole.CUSTOMER
-        );
-
-        Authentication customerAuthentication = new UsernamePasswordAuthenticationToken(
-                customerAuthUser,
-                null,
-                customerAuthUser.getAuthorities()
-        );
-
-        // when
-        ResultActions resultActions = mockMvc.perform(
-                post("/api/v1/categories")
-                        .with(authentication(customerAuthentication))
-                        .contentType("application/json")
-                        .content(objectMapper.writeValueAsString(categoryRequest))
-        );
-
-        // then
-        resultActions.andExpect(status().isForbidden());
-    }
-
-    @Test
-    @DisplayName("예외: 카테고리 생성 - 중복된 이름")
-    void createCategory_Duplication() throws Exception {
-        // given
-        given(categoryService.createCategory(
-                any(ReqCategoryDtoV1.class),
-                eq(testAuthUser.getUserId()),
-                eq(testAuthUser.role().name())
-        )).willThrow(new RuntimeException("CATEGORY_DUPLICATION"));
-
-        // when
-        ResultActions resultActions = mockMvc.perform(
-                post("/api/v1/categories")
-                        .with(authentication(testAuthentication))
-                        .contentType("application/json")
-                        .content(objectMapper.writeValueAsString(categoryRequest))
-        );
-
-        // then
-        resultActions.andExpect(status().is4xxClientError());
-    }
-
-    @Test
-    @DisplayName("예외: 카테고리 생성 - 유효하지 않은 요청")
-    void createCategory_InvalidRequest() throws Exception {
-        // given
-        ReqCategoryDtoV1 invalidRequest = new ReqCategoryDtoV1("");
-
-        // when
-        ResultActions resultActions = mockMvc.perform(
-                post("/api/v1/categories")
-                        .with(csrf())
-                        .with(authentication(testAuthentication))
-                        .contentType("application/json")
-                        .content(objectMapper.writeValueAsString(invalidRequest))
-        );
-
-        // then
-        resultActions.andExpect(status().isBadRequest());
+        resultActions
+                .andExpect(status().isCreated())
+                .andExpect(header().exists("Location"))
+                .andExpect(jsonPath("$.categoryId", equalTo(testCategoryId.toString())))
+                .andExpect(jsonPath("$.name", equalTo("한식")));
     }
 
     // ============ PUT /api/v1/categories/{category_id} ============
@@ -357,6 +454,19 @@ class CategoryControllerV1Test {
     @Test
     @DisplayName("정상: 카테고리 수정")
     void updateCategory_Success() throws Exception {
+
+        AuthUser managerAuthUser = new AuthUser(
+                UUID.randomUUID(),
+                "manager@example.com",
+                UserRole.MANAGER
+        );
+
+        Authentication managerAuthentication = new UsernamePasswordAuthenticationToken(
+                managerAuthUser,
+                null,
+                managerAuthUser.getAuthorities()
+        );
+
         // given
         ReqCategoryDtoV1 updateRequest = new ReqCategoryDtoV1("한식 (수정됨)");
 
@@ -367,16 +477,16 @@ class CategoryControllerV1Test {
 
         given(categoryService.updateCategory(
                 eq(testCategoryId),
-                any(ReqCategoryDtoV1.class),
-                eq(testAuthUser.getUserId()),
-                eq(testAuthUser.role().name())
+                any(),
+                eq(managerAuthUser.getUserId()),
+                eq(UserRole.MANAGER.name())
         )).willReturn(mockResponse);
 
         // when
         ResultActions resultActions = mockMvc.perform(
                 put("/api/v1/categories/{category_id}", testCategoryId)
                         .with(csrf())
-                        .with(authentication(testAuthentication))
+                        .with(authentication(managerAuthentication))
                         .contentType("application/json")
                         .content(objectMapper.writeValueAsString(updateRequest))
         );
@@ -384,71 +494,7 @@ class CategoryControllerV1Test {
         // then
         resultActions
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.categoryId", equalTo(testCategoryId.toString())))
                 .andExpect(jsonPath("$.name", equalTo("한식 (수정됨)")));
-
-        verify(categoryService, times(1)).updateCategory(
-                eq(testCategoryId),
-                any(ReqCategoryDtoV1.class),
-                eq(testAuthUser.getUserId()),
-                eq(testAuthUser.role().name())
-        );
-    }
-
-    @Test
-    @DisplayName("예외: 카테고리 수정 - CUSTOMER 역할 (권한 없음)")
-    void updateCategory_CustomerRole_Forbidden() throws Exception {
-        // given
-        AuthUser customerAuthUser = new AuthUser(
-                UUID.randomUUID(),
-                "customer@example.com",
-                UserRole.CUSTOMER
-        );
-
-        Authentication customerAuthentication = new UsernamePasswordAuthenticationToken(
-                customerAuthUser,
-                null,
-                customerAuthUser.getAuthorities()
-        );
-
-        ReqCategoryDtoV1 updateRequest = new ReqCategoryDtoV1("한식 (수정됨)");
-
-        // when
-        ResultActions resultActions = mockMvc.perform(
-                put("/api/v1/categories/{category_id}", testCategoryId)
-                        .with(authentication(customerAuthentication))
-                        .contentType("application/json")
-                        .content(objectMapper.writeValueAsString(updateRequest))
-        );
-
-        // then
-        resultActions.andExpect(status().isForbidden());
-    }
-
-    @Test
-    @DisplayName("예외: 카테고리 수정 - 존재하지 않는 카테고리")
-    void updateCategory_NotFound() throws Exception {
-        // given
-        UUID nonExistentId = UUID.randomUUID();
-        ReqCategoryDtoV1 updateRequest = new ReqCategoryDtoV1("한식 (수정됨)");
-
-        given(categoryService.updateCategory(
-                eq(nonExistentId),
-                any(ReqCategoryDtoV1.class),
-                eq(testAuthUser.getUserId()),
-                eq(testAuthUser.role().name())
-        )).willThrow(new IllegalArgumentException("존재하지 않는 카테고리입니다."));
-
-        // when
-        ResultActions resultActions = mockMvc.perform(
-                put("/api/v1/categories/{category_id}", nonExistentId)
-                        .with(authentication(testAuthentication))
-                        .contentType("application/json")
-                        .content(objectMapper.writeValueAsString(updateRequest))
-        );
-
-        // then
-        resultActions.andExpect(status().is4xxClientError());
     }
 
     // ============ DELETE /api/v1/categories/{category_id} ============
@@ -457,74 +503,26 @@ class CategoryControllerV1Test {
     @DisplayName("정상: 카테고리 삭제")
     void deleteCategory_Success() throws Exception {
         // given
-        willDoNothing().given(categoryService).deleteCategory(
-                eq(testCategoryId),
-                eq(testAuthUser.getUserId()),
-                eq(testAuthUser.role().name())
+        doNothing().when(categoryService).deleteCategory(
+                any(UUID.class),
+                any(UUID.class),
+                any(String.class)
         );
 
         // when
         ResultActions resultActions = mockMvc.perform(
                 delete("/api/v1/categories/{category_id}", testCategoryId)
+                        .with(authentication(testAuthentication))  // ✅ @WithMockUser 대신 사용
                         .with(csrf())
-                        .with(authentication(testAuthentication))
         );
 
         // then
         resultActions.andExpect(status().isNoContent());
 
         verify(categoryService, times(1)).deleteCategory(
-                eq(testCategoryId),
-                eq(testAuthUser.getUserId()),
-                eq(testAuthUser.role().name())
+                any(UUID.class),
+                any(UUID.class),
+                any(String.class)
         );
-    }
-
-    @Test
-    @DisplayName("예외: 카테고리 삭제 - CUSTOMER 역할 (권한 없음)")
-    void deleteCategory_CustomerRole_Forbidden() throws Exception {
-        // given
-        AuthUser customerAuthUser = new AuthUser(
-                UUID.randomUUID(),
-                "customer@example.com",
-                UserRole.CUSTOMER
-        );
-
-        Authentication customerAuthentication = new UsernamePasswordAuthenticationToken(
-                customerAuthUser,
-                null,
-                customerAuthUser.getAuthorities()
-        );
-
-        // when
-        ResultActions resultActions = mockMvc.perform(
-                delete("/api/v1/categories/{category_id}", testCategoryId)
-                        .with(authentication(customerAuthentication))
-        );
-
-        // then
-        resultActions.andExpect(status().isForbidden());
-    }
-
-    @Test
-    @DisplayName("예외: 카테고리 삭제 - 존재하지 않는 카테고리")
-    void deleteCategory_NotFound() throws Exception {
-        // given
-        UUID nonExistentId = UUID.randomUUID();
-        doThrow(new IllegalArgumentException("존재하지 않는 카테고리입니다."))
-                .when(categoryService)
-                .deleteCategory(
-                        eq(nonExistentId),
-                        eq(testAuthUser.getUserId()),
-                        eq(testAuthUser.role().name())
-                );
-        // when
-        ResultActions resultActions = mockMvc.perform(
-                delete("/api/v1/categories/{category_id}", nonExistentId)
-                        .with(authentication(testAuthentication))
-        );
-
-        // then
-        resultActions.andExpect(status().is4xxClientError());
     }
 }

--- a/src/test/java/com/example/whostolemyfood/category/CategoryControllerV1Test.java
+++ b/src/test/java/com/example/whostolemyfood/category/CategoryControllerV1Test.java
@@ -1,0 +1,530 @@
+package com.example.whostolemyfood.category;
+
+
+import com.example.whostolemyfood.category.application.service.CategoryServiceV1;
+import com.example.whostolemyfood.category.domain.repository.CategoryRepository;
+import com.example.whostolemyfood.category.presentation.controller.CategoryControllerV1;
+import com.example.whostolemyfood.category.presentation.dto.request.ReqCategoryDtoV1;
+import com.example.whostolemyfood.category.presentation.dto.response.ResGetCategoryDtoV1;
+import com.example.whostolemyfood.global.config.security.jwt.JwtUtil;
+import com.example.whostolemyfood.user.application.security.AuthUser;
+import com.example.whostolemyfood.user.domain.entity.UserRole;
+import com.example.whostolemyfood.user.domain.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(CategoryControllerV1.class)
+@AutoConfigureMockMvc
+@DisplayName("CategoryControllerV1 테스트")
+class CategoryControllerV1Test {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CategoryServiceV1 categoryService;
+
+    @MockitoBean
+    private CategoryRepository categoryRepository;
+
+    @MockitoBean
+    private UserRepository userRepository;
+
+    @MockitoBean
+    private JwtUtil jwtUtil;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private UUID testUserId;
+    private AuthUser testAuthUser;
+    private Authentication testAuthentication;
+    private UUID testCategoryId;
+    private ReqCategoryDtoV1 categoryRequest;
+
+    @BeforeEach
+    void setUp() {
+        testUserId = UUID.randomUUID();
+        testCategoryId = UUID.randomUUID();
+
+        // ✅ AuthUser 생성 (MANAGER 역할)
+        testAuthUser = new AuthUser(
+                testUserId,
+                "manager@example.com",
+                UserRole.MANAGER
+        );
+
+        // ✅ Authentication 생성
+        testAuthentication = new UsernamePasswordAuthenticationToken(
+                testAuthUser,
+                null,
+                testAuthUser.getAuthorities()
+        );
+
+
+        categoryRequest = new ReqCategoryDtoV1("한식");
+    }
+
+    // ============ GET /api/v1/categories ============
+
+    @Test
+    @DisplayName("정상: 카테고리 목록 조회")
+    void getCategories_Success() throws Exception {
+        // given
+        List<ResGetCategoryDtoV1> mockCategories = List.of(
+                ResGetCategoryDtoV1.builder()
+                        .categoryId(UUID.randomUUID())
+                        .name("한식")
+                        .build(),
+                ResGetCategoryDtoV1.builder()
+                        .categoryId(UUID.randomUUID())
+                        .name("일식")
+                        .build(),
+                ResGetCategoryDtoV1.builder()
+                        .categoryId(UUID.randomUUID())
+                        .name("중식")
+                        .build()
+        );
+
+        given(categoryService.getCategories(
+                eq(testAuthUser.getUserId()),
+                eq(testAuthUser.role().name())
+        )).willReturn(mockCategories);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/v1/categories")
+                        .with(authentication(testAuthentication))
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(3)))
+                .andExpect(jsonPath("$[0].name", equalTo("한식")))
+                .andExpect(jsonPath("$[1].name", equalTo("일식")))
+                .andExpect(jsonPath("$[2].name", equalTo("중식")));
+
+        verify(categoryService, times(1)).getCategories(
+                eq(testAuthUser.getUserId()),
+                eq(testAuthUser.role().name())
+        );
+    }
+
+    @Test
+    @DisplayName("정상: 카테고리 목록 조회 - 빈 결과")
+    void getCategories_Empty() throws Exception {
+        // given
+        given(categoryService.getCategories(
+                eq(testAuthUser.getUserId()),
+                eq(testAuthUser.role().name())
+        )).willReturn(List.of());
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/v1/categories")
+                        .with(authentication(testAuthentication))
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(0)));
+    }
+
+    // ============ GET /api/v1/categories/{category_id} ============
+
+    @Test
+    @DisplayName("정상: 카테고리 상세 조회")
+    void getCategory_Success() throws Exception {
+        // given
+        ResGetCategoryDtoV1 mockCategory = ResGetCategoryDtoV1.builder()
+                .categoryId(testCategoryId)
+                .name("한식")
+                .build();
+
+        given(categoryService.getCategory(
+                eq(testCategoryId),
+                eq(testAuthUser.getUserId()),
+                eq(testAuthUser.role().name())
+        )).willReturn(mockCategory);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/v1/categories/{category_id}", testCategoryId)
+                        .with(authentication(testAuthentication))
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.categoryId", equalTo(testCategoryId.toString())))
+                .andExpect(jsonPath("$.name", equalTo("한식")));
+
+        verify(categoryService, times(1)).getCategory(
+                eq(testCategoryId),
+                eq(testAuthUser.getUserId()),
+                eq(testAuthUser.role().name())
+        );
+    }
+
+    @Test
+    @DisplayName("예외: 존재하지 않는 카테고리 조회")
+    void getCategory_NotFound() throws Exception {
+        // given
+        UUID nonExistentId = UUID.randomUUID();
+        given(categoryService.getCategory(
+                eq(nonExistentId),
+                eq(testAuthUser.getUserId()),
+                eq(testAuthUser.role().name())
+        )).willThrow(new IllegalArgumentException("존재하지 않는 카테고리입니다."));
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/v1/categories/{category_id}", nonExistentId)
+                        .with(authentication(testAuthentication))
+        );
+
+        // then
+        resultActions.andExpect(status().is4xxClientError());
+    }
+
+    // ============ POST /api/v1/categories ============
+
+    @Test
+    @DisplayName("정상: 카테고리 생성 - MANAGER 역할")
+    void createCategory_Success() throws Exception {
+        // given
+        ResGetCategoryDtoV1 mockResponse = ResGetCategoryDtoV1.builder()
+                .categoryId(testCategoryId)
+                .name("한식")
+                .build();
+
+
+        given(categoryService.createCategory(
+                any(),  // ReqCategoryDtoV1
+                any(),  // userId
+                any()   // role
+        )).willReturn(mockResponse);
+
+        // when & then
+        mockMvc.perform(
+                        post("/api/v1/categories")
+                                .with(csrf())
+                                .with(authentication(testAuthentication))
+                                .contentType("application/json")
+                                .content(objectMapper.writeValueAsString(categoryRequest))
+                )
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("정상: 카테고리 생성 - MASTER 역할")
+    void createCategory_MasterRole() throws Exception {
+        // given
+        AuthUser masterAuthUser = new AuthUser(
+                UUID.randomUUID(),
+                "master@example.com",
+                UserRole.MASTER
+        );
+
+        Authentication masterAuthentication = new UsernamePasswordAuthenticationToken(
+                masterAuthUser,
+                null,
+                masterAuthUser.getAuthorities()
+        );
+
+        ResGetCategoryDtoV1 mockResponse = ResGetCategoryDtoV1.builder()
+                .categoryId(testCategoryId)
+                .name("한식")
+                .build();
+
+        given(categoryService.createCategory(
+                any(ReqCategoryDtoV1.class),
+                any(UUID.class),  // ← any() 사용 (UUID 검증 안함)
+                any(String.class)  // ← any() 사용 (Role 문자열 검증 안함)
+        )).willReturn(mockResponse);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/v1/categories")
+                        .with(csrf())
+                        .with(authentication(masterAuthentication))
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(categoryRequest))
+        );
+
+        // then
+        resultActions.andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("예외: 카테고리 생성 - CUSTOMER 역할 (권한 없음)")
+    void createCategory_CustomerRole_Forbidden() throws Exception {
+        // given
+        AuthUser customerAuthUser = new AuthUser(
+                UUID.randomUUID(),
+                "customer@example.com",
+                UserRole.CUSTOMER
+        );
+
+        Authentication customerAuthentication = new UsernamePasswordAuthenticationToken(
+                customerAuthUser,
+                null,
+                customerAuthUser.getAuthorities()
+        );
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/v1/categories")
+                        .with(authentication(customerAuthentication))
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(categoryRequest))
+        );
+
+        // then
+        resultActions.andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("예외: 카테고리 생성 - 중복된 이름")
+    void createCategory_Duplication() throws Exception {
+        // given
+        given(categoryService.createCategory(
+                any(ReqCategoryDtoV1.class),
+                eq(testAuthUser.getUserId()),
+                eq(testAuthUser.role().name())
+        )).willThrow(new RuntimeException("CATEGORY_DUPLICATION"));
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/v1/categories")
+                        .with(authentication(testAuthentication))
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(categoryRequest))
+        );
+
+        // then
+        resultActions.andExpect(status().is4xxClientError());
+    }
+
+    @Test
+    @DisplayName("예외: 카테고리 생성 - 유효하지 않은 요청")
+    void createCategory_InvalidRequest() throws Exception {
+        // given
+        ReqCategoryDtoV1 invalidRequest = new ReqCategoryDtoV1("");
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/v1/categories")
+                        .with(csrf())
+                        .with(authentication(testAuthentication))
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(invalidRequest))
+        );
+
+        // then
+        resultActions.andExpect(status().isBadRequest());
+    }
+
+    // ============ PUT /api/v1/categories/{category_id} ============
+
+    @Test
+    @DisplayName("정상: 카테고리 수정")
+    void updateCategory_Success() throws Exception {
+        // given
+        ReqCategoryDtoV1 updateRequest = new ReqCategoryDtoV1("한식 (수정됨)");
+
+        ResGetCategoryDtoV1 mockResponse = ResGetCategoryDtoV1.builder()
+                .categoryId(testCategoryId)
+                .name("한식 (수정됨)")
+                .build();
+
+        given(categoryService.updateCategory(
+                eq(testCategoryId),
+                any(ReqCategoryDtoV1.class),
+                eq(testAuthUser.getUserId()),
+                eq(testAuthUser.role().name())
+        )).willReturn(mockResponse);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                put("/api/v1/categories/{category_id}", testCategoryId)
+                        .with(csrf())
+                        .with(authentication(testAuthentication))
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(updateRequest))
+        );
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.categoryId", equalTo(testCategoryId.toString())))
+                .andExpect(jsonPath("$.name", equalTo("한식 (수정됨)")));
+
+        verify(categoryService, times(1)).updateCategory(
+                eq(testCategoryId),
+                any(ReqCategoryDtoV1.class),
+                eq(testAuthUser.getUserId()),
+                eq(testAuthUser.role().name())
+        );
+    }
+
+    @Test
+    @DisplayName("예외: 카테고리 수정 - CUSTOMER 역할 (권한 없음)")
+    void updateCategory_CustomerRole_Forbidden() throws Exception {
+        // given
+        AuthUser customerAuthUser = new AuthUser(
+                UUID.randomUUID(),
+                "customer@example.com",
+                UserRole.CUSTOMER
+        );
+
+        Authentication customerAuthentication = new UsernamePasswordAuthenticationToken(
+                customerAuthUser,
+                null,
+                customerAuthUser.getAuthorities()
+        );
+
+        ReqCategoryDtoV1 updateRequest = new ReqCategoryDtoV1("한식 (수정됨)");
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                put("/api/v1/categories/{category_id}", testCategoryId)
+                        .with(authentication(customerAuthentication))
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(updateRequest))
+        );
+
+        // then
+        resultActions.andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("예외: 카테고리 수정 - 존재하지 않는 카테고리")
+    void updateCategory_NotFound() throws Exception {
+        // given
+        UUID nonExistentId = UUID.randomUUID();
+        ReqCategoryDtoV1 updateRequest = new ReqCategoryDtoV1("한식 (수정됨)");
+
+        given(categoryService.updateCategory(
+                eq(nonExistentId),
+                any(ReqCategoryDtoV1.class),
+                eq(testAuthUser.getUserId()),
+                eq(testAuthUser.role().name())
+        )).willThrow(new IllegalArgumentException("존재하지 않는 카테고리입니다."));
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                put("/api/v1/categories/{category_id}", nonExistentId)
+                        .with(authentication(testAuthentication))
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(updateRequest))
+        );
+
+        // then
+        resultActions.andExpect(status().is4xxClientError());
+    }
+
+    // ============ DELETE /api/v1/categories/{category_id} ============
+
+    @Test
+    @DisplayName("정상: 카테고리 삭제")
+    void deleteCategory_Success() throws Exception {
+        // given
+        willDoNothing().given(categoryService).deleteCategory(
+                eq(testCategoryId),
+                eq(testAuthUser.getUserId()),
+                eq(testAuthUser.role().name())
+        );
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                delete("/api/v1/categories/{category_id}", testCategoryId)
+                        .with(csrf())
+                        .with(authentication(testAuthentication))
+        );
+
+        // then
+        resultActions.andExpect(status().isNoContent());
+
+        verify(categoryService, times(1)).deleteCategory(
+                eq(testCategoryId),
+                eq(testAuthUser.getUserId()),
+                eq(testAuthUser.role().name())
+        );
+    }
+
+    @Test
+    @DisplayName("예외: 카테고리 삭제 - CUSTOMER 역할 (권한 없음)")
+    void deleteCategory_CustomerRole_Forbidden() throws Exception {
+        // given
+        AuthUser customerAuthUser = new AuthUser(
+                UUID.randomUUID(),
+                "customer@example.com",
+                UserRole.CUSTOMER
+        );
+
+        Authentication customerAuthentication = new UsernamePasswordAuthenticationToken(
+                customerAuthUser,
+                null,
+                customerAuthUser.getAuthorities()
+        );
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                delete("/api/v1/categories/{category_id}", testCategoryId)
+                        .with(authentication(customerAuthentication))
+        );
+
+        // then
+        resultActions.andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("예외: 카테고리 삭제 - 존재하지 않는 카테고리")
+    void deleteCategory_NotFound() throws Exception {
+        // given
+        UUID nonExistentId = UUID.randomUUID();
+        doThrow(new IllegalArgumentException("존재하지 않는 카테고리입니다."))
+                .when(categoryService)
+                .deleteCategory(
+                        eq(nonExistentId),
+                        eq(testAuthUser.getUserId()),
+                        eq(testAuthUser.role().name())
+                );
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                delete("/api/v1/categories/{category_id}", nonExistentId)
+                        .with(authentication(testAuthentication))
+        );
+
+        // then
+        resultActions.andExpect(status().is4xxClientError());
+    }
+}

--- a/src/test/java/com/example/whostolemyfood/category/CategoryRepositoryV1Test.java
+++ b/src/test/java/com/example/whostolemyfood/category/CategoryRepositoryV1Test.java
@@ -1,0 +1,428 @@
+package com.example.whostolemyfood.category;
+
+import com.example.whostolemyfood.category.domain.entity.CategoryEntity;
+import com.example.whostolemyfood.category.domain.repository.CategoryRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DisplayName("Category Repository 단위 테스트")
+class CategoryRepositoryV1Test {
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private UUID categoryId1;
+    private UUID categoryId2;
+    private UUID categoryId3;
+
+    @BeforeEach
+    @Transactional
+    void setUp() {
+        // 테이블 초기화
+        categoryRepository.deleteAll();
+        em.flush();
+        em.clear();
+
+        // 테스트 데이터 생성
+        CategoryEntity category1 = CategoryEntity.builder()
+                .name("한식")
+                .build();
+        category1 = categoryRepository.save(category1);
+        categoryId1 = category1.getCategoryId();
+
+        CategoryEntity category2 = CategoryEntity.builder()
+                .name("일식")
+                .build();
+        category2 = categoryRepository.save(category2);
+        categoryId2 = category2.getCategoryId();
+
+        CategoryEntity category3 = CategoryEntity.builder()
+                .name("중식")
+                .build();
+        category3 = categoryRepository.save(category3);
+        categoryId3 = category3.getCategoryId();
+
+        em.flush();
+        em.clear();
+    }
+
+    // ============ findByCategoryIdAndIsDeletedFalse ============
+
+    @Test
+    @Transactional
+    @DisplayName("정상: 활성 카테고리 조회 성공")
+    void findByCategoryIdAndIsDeletedFalse_Success() {
+        // given
+        // setUp에서 이미 생성됨
+
+        // when
+        Optional<CategoryEntity> result = categoryRepository.findByCategoryIdAndIsDeletedFalse(categoryId1);
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getName()).isEqualTo("한식");
+        assertThat(result.get().getIsDeleted()).isFalse();
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("정상: 존재하지 않는 카테고리 - 빈 Optional 반환")
+    void findByCategoryIdAndIsDeletedFalse_NotFound() {
+        // given
+        UUID nonExistentId = UUID.randomUUID();
+
+        // when
+        Optional<CategoryEntity> result = categoryRepository.findByCategoryIdAndIsDeletedFalse(nonExistentId);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("정상: 삭제된 카테고리 조회 - 빈 Optional 반환")
+    void findByCategoryIdAndIsDeletedFalse_DeletedCategory() {
+        // given
+        CategoryEntity category = categoryRepository.findById(categoryId1).orElseThrow();
+        category.softDelete();
+        categoryRepository.save(category);
+        em.flush();
+        em.clear();
+
+        // when
+        Optional<CategoryEntity> result = categoryRepository.findByCategoryIdAndIsDeletedFalse(categoryId1);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("정상: 여러 카테고리 중 특정 카테고리 조회")
+    void findByCategoryIdAndIsDeletedFalse_SpecificCategory() {
+        // given
+        // setUp에서 3개 생성됨
+
+        // when
+        Optional<CategoryEntity> result2 = categoryRepository.findByCategoryIdAndIsDeletedFalse(categoryId2);
+        Optional<CategoryEntity> result3 = categoryRepository.findByCategoryIdAndIsDeletedFalse(categoryId3);
+
+        // then
+        assertThat(result2).isPresent();
+        assertThat(result2.get().getName()).isEqualTo("일식");
+
+        assertThat(result3).isPresent();
+        assertThat(result3.get().getName()).isEqualTo("중식");
+    }
+
+    // ============ existsByNameAndIsDeletedFalse ============
+
+    @Test
+    @Transactional
+    @DisplayName("정상: 활성 카테고리 존재 확인 - true")
+    void existsByNameAndIsDeletedFalse_Exists() {
+        // given
+        // setUp에서 이미 생성됨
+
+        // when
+        boolean result = categoryRepository.existsByNameAndIsDeletedFalse("한식");
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("정상: 존재하지 않는 카테고리 - false")
+    void existsByNameAndIsDeletedFalse_NotExists() {
+        // given
+        String nonExistentName = "없는음식";
+
+        // when
+        boolean result = categoryRepository.existsByNameAndIsDeletedFalse(nonExistentName);
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("정상: 삭제된 카테고리는 존재하지 않는 것으로 판단")
+    void existsByNameAndIsDeletedFalse_DeletedCategory() {
+        // given
+        CategoryEntity category = categoryRepository.findById(categoryId1).orElseThrow();
+        category.softDelete();
+        categoryRepository.save(category);
+        em.flush();
+        em.clear();
+
+        // when
+        boolean result = categoryRepository.existsByNameAndIsDeletedFalse("한식");
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("정상: 중복된 이름 체크 - 여러 활성 카테고리")
+    void existsByNameAndIsDeletedFalse_MultipleActive() {
+        // given
+        // setUp에서 3개 생성됨
+
+        // when
+        boolean result1 = categoryRepository.existsByNameAndIsDeletedFalse("한식");
+        boolean result2 = categoryRepository.existsByNameAndIsDeletedFalse("일식");
+        boolean result3 = categoryRepository.existsByNameAndIsDeletedFalse("중식");
+
+        // then
+        assertThat(result1).isTrue();
+        assertThat(result2).isTrue();
+        assertThat(result3).isTrue();
+    }
+
+    // ============ softdelete + unique 통합 테스트 ============
+
+    @Test
+    @Transactional
+    @DisplayName("정상: softdelete 후 같은 이름으로 재생성 가능")
+    void softDeleteAndRecreateWithSameName() {
+        // given
+        String categoryName = "한식";
+        UUID originalId = categoryId1;
+
+        // 1. 원본 카테고리 조회
+        CategoryEntity original = categoryRepository.findById(originalId).orElseThrow();
+        assertThat(original.getName()).isEqualTo(categoryName);
+
+        // 2. 원본 카테고리 softdelete
+        original.softDelete();
+        categoryRepository.save(original);
+        em.flush();
+        em.clear();
+
+        // 3. softdelete 확인 - 삭제된 것으로 보임
+        Optional<CategoryEntity> deletedResult = categoryRepository.findByCategoryIdAndIsDeletedFalse(originalId);
+        assertThat(deletedResult).isEmpty();
+
+        boolean existsAfterDelete = categoryRepository.existsByNameAndIsDeletedFalse(categoryName);
+        assertThat(existsAfterDelete).isFalse();
+
+        // when
+        // 4. 같은 이름으로 새 카테고리 생성
+        CategoryEntity newCategory = CategoryEntity.builder()
+                .name(categoryName)
+                .build();
+        newCategory = categoryRepository.save(newCategory);
+        em.flush();
+        em.clear();
+
+        // then
+        // 5. 새 카테고리 생성 확인
+        assertThat(newCategory.getCategoryId()).isNotEqualTo(originalId);
+        assertThat(newCategory.getName()).isEqualTo(categoryName);
+
+        // 6. 새 카테고리 조회 가능
+        Optional<CategoryEntity> recreatedResult = categoryRepository.findByCategoryIdAndIsDeletedFalse(newCategory.getCategoryId());
+        assertThat(recreatedResult).isPresent();
+        assertThat(recreatedResult.get().getName()).isEqualTo(categoryName);
+
+        // 7. 활성 카테고리로 존재 확인
+        boolean existsAfterRecreate = categoryRepository.existsByNameAndIsDeletedFalse(categoryName);
+        assertThat(existsAfterRecreate).isTrue();
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("정상: 하나는 활성, 하나는 삭제 상태 - 같은 이름 허용")
+    void sameNameWithDifferentDeletedStatus() {
+        // given
+        String categoryName = "한식";
+
+        // 1. 원본 카테고리 softdelete
+        CategoryEntity original = categoryRepository.findById(categoryId1).orElseThrow();
+        original.softDelete();
+        categoryRepository.save(original);
+        em.flush();
+
+        // 2. 같은 이름으로 새 카테고리 생성 (아직 활성)
+        CategoryEntity newCategory = CategoryEntity.builder()
+                .name(categoryName)
+                .build();
+        newCategory = categoryRepository.save(newCategory);
+        em.flush();
+        em.clear();
+
+        // when
+        // 3. 활성 카테고리만 조회
+        Optional<CategoryEntity> result = categoryRepository.findByCategoryIdAndIsDeletedFalse(newCategory.getCategoryId());
+        boolean existsActive = categoryRepository.existsByNameAndIsDeletedFalse(categoryName);
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getName()).isEqualTo(categoryName);
+        assertThat(existsActive).isTrue();
+
+        // 4. 원본은 여전히 삭제 상태
+        Optional<CategoryEntity> deletedResult = categoryRepository.findByCategoryIdAndIsDeletedFalse(categoryId1);
+        assertThat(deletedResult).isEmpty();
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("정상: 카테고리 삭제 후 동일 이름 재생성 여러 번")
+    void multipleDeleteAndRecreate() {
+        // given
+        String categoryName = "한식";
+
+        // 1. 첫 번째 생성 및 삭제
+        CategoryEntity cat1 = categoryRepository.findById(categoryId1).orElseThrow();
+        cat1.softDelete();
+        categoryRepository.save(cat1);
+        em.flush();
+
+        // 2. 두 번째 생성
+        CategoryEntity cat2 = CategoryEntity.builder()
+                .name(categoryName)
+                .build();
+        cat2 = categoryRepository.save(cat2);
+        UUID cat2Id = cat2.getCategoryId();
+        em.flush();
+
+        // 3. 두 번째 삭제
+        cat2.softDelete();
+        categoryRepository.save(cat2);
+        em.flush();
+
+        // when & then
+        // 4. 세 번째 생성
+        CategoryEntity cat3 = CategoryEntity.builder()
+                .name(categoryName)
+                .build();
+        cat3 = categoryRepository.save(cat3);
+        em.flush();
+        em.clear();
+
+        // 모두 다른 ID
+        assertThat(cat3.getCategoryId()).isNotEqualTo(categoryId1);
+        assertThat(cat3.getCategoryId()).isNotEqualTo(cat2Id);
+
+        // 활성인 것은 cat3만
+        boolean exists = categoryRepository.existsByNameAndIsDeletedFalse(categoryName);
+        assertThat(exists).isTrue();
+
+        Optional<CategoryEntity> result = categoryRepository.findByCategoryIdAndIsDeletedFalse(cat3.getCategoryId());
+        assertThat(result).isPresent();
+    }
+
+    // ============ 엣지 케이스 ============
+
+    @Test
+    @Transactional
+    @DisplayName("정상: 공백이 포함된 카테고리 이름")
+    void categoryNameWithSpaces() {
+        // given
+        String categoryName = "한식 (밥 포함)";
+        CategoryEntity category = CategoryEntity.builder()
+                .name(categoryName)
+                .build();
+        category = categoryRepository.save(category);
+        em.flush();
+        em.clear();
+
+        // when
+        boolean exists = categoryRepository.existsByNameAndIsDeletedFalse(categoryName);
+        Optional<CategoryEntity> result = categoryRepository.findByCategoryIdAndIsDeletedFalse(category.getCategoryId());
+
+        // then
+        assertThat(exists).isTrue();
+        assertThat(result).isPresent();
+        assertThat(result.get().getName()).isEqualTo(categoryName);
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("정상: 특수문자가 포함된 카테고리 이름")
+    void categoryNameWithSpecialCharacters() {
+        // given
+        String categoryName = "한식/일식/중식";
+        CategoryEntity category = CategoryEntity.builder()
+                .name(categoryName)
+                .build();
+        category = categoryRepository.save(category);
+        em.flush();
+        em.clear();
+
+        // when
+        boolean exists = categoryRepository.existsByNameAndIsDeletedFalse(categoryName);
+
+        // then
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("정상: 매우 긴 카테고리 이름")
+    void categoryNameVeryLong() {
+        // given
+        String categoryName = "한식".repeat(50);  // 매우 긴 이름
+        CategoryEntity category = CategoryEntity.builder()
+                .name(categoryName)
+                .build();
+        category = categoryRepository.save(category);
+        em.flush();
+        em.clear();
+
+        // when
+        boolean exists = categoryRepository.existsByNameAndIsDeletedFalse(categoryName);
+
+        // then
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("정상: null 카테고리 ID로 조회")
+    void findByCategoryIdAndIsDeletedFalse_NullId() {
+        // given
+        UUID nullId = null;
+
+        // when & then
+        // null ID로 조회하면 empty 반환
+        Optional<CategoryEntity> result = categoryRepository.findByCategoryIdAndIsDeletedFalse(nullId);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("정상: 빈 문자열로 존재 여부 확인")
+    void existsByNameAndIsDeletedFalse_EmptyString() {
+        // given
+        String emptyName = "";
+
+        // when
+        boolean exists = categoryRepository.existsByNameAndIsDeletedFalse(emptyName);
+
+        // then
+        assertThat(exists).isFalse();
+    }
+}

--- a/src/test/java/com/example/whostolemyfood/category/CategoryServiceV1Test.java
+++ b/src/test/java/com/example/whostolemyfood/category/CategoryServiceV1Test.java
@@ -7,6 +7,7 @@ import com.example.whostolemyfood.category.presentation.dto.request.ReqCategoryD
 import com.example.whostolemyfood.category.presentation.dto.response.ResGetCategoryDtoV1;
 import com.example.whostolemyfood.global.exception.CustomException;
 import com.example.whostolemyfood.global.exception.ErrorCode;
+import com.example.whostolemyfood.global.response.PageResponse;
 import com.example.whostolemyfood.user.domain.entity.UserEntity;
 import com.example.whostolemyfood.user.domain.entity.UserRole;
 import com.example.whostolemyfood.user.domain.repository.UserRepository;
@@ -17,6 +18,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
@@ -33,7 +38,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("CategoryServiceV1 테스트")
+@DisplayName("Category Service 단위 테스트 (Pageable 적용)")
 class CategoryServiceV1Test {
 
     @Mock
@@ -50,6 +55,7 @@ class CategoryServiceV1Test {
     private UserEntity testUser;
     private UserEntity managerUser;
     private UserEntity masterUser;
+    private Pageable pageable;
 
     @BeforeEach
     void setUp() {
@@ -81,6 +87,7 @@ class CategoryServiceV1Test {
                 .role(UserRole.MASTER)
                 .build();
         ReflectionTestUtils.setField(masterUser, "id", masterId);
+        pageable = PageRequest.of(0, 10);
     }
 
     // ============ createCategory ============
@@ -336,21 +343,29 @@ class CategoryServiceV1Test {
 
         given(userRepository.findById(managerUser.getId()))
                 .willReturn(Optional.of(managerUser));
-        given(categoryRepository.findAll())
-                .willReturn(List.of(category1, category2, category3));
+        given(categoryRepository.findByIsDeletedFalse(any(Pageable.class)))
+                .willReturn(new PageImpl<>(
+                        List.of(category1, category2, category3),
+                        pageable,
+                        3
+                ));
 
         // when
-        List<ResGetCategoryDtoV1> result = categoryService.getCategories(
+        PageResponse<ResGetCategoryDtoV1> result = categoryService.getCategories(
                 managerUser.getId(),
-                UserRole.MANAGER.name()
+                UserRole.MANAGER.name(),
+                pageable
         );
 
         // then
-        assertThat(result).hasSize(3);
-        assertThat(result.get(0).getName()).isEqualTo("한식");
-        assertThat(result.get(1).getName()).isEqualTo("일식");
-        assertThat(result.get(2).getName()).isEqualTo("중식");
-        verify(categoryRepository, times(1)).findAll();
+        // ✅ 수정 (PageResponse 기준)
+        assertThat(result.getContent()).hasSize(3);
+        assertThat(result.getContent().get(0).getName()).isEqualTo("한식");
+        assertThat(result.getContent().get(1).getName()).isEqualTo("일식");
+        assertThat(result.getContent().get(2).getName()).isEqualTo("중식");
+        assertThat(result.getTotalElements()).isEqualTo(3);
+        assertThat(result.getTotalPages()).isEqualTo(1);
+        verify(categoryRepository, times(1)).findByIsDeletedFalse(any(Pageable.class));
     }
 
     @Test
@@ -359,17 +374,25 @@ class CategoryServiceV1Test {
         // given
         given(userRepository.findById(managerUser.getId()))
                 .willReturn(Optional.of(managerUser));
-        given(categoryRepository.findAll())
-                .willReturn(List.of());
+        given(categoryRepository.findByIsDeletedFalse(any(Pageable.class)))
+                .willReturn(new PageImpl<>(
+                        List.of(),
+                        pageable,
+                        0
+                ));
 
         // when
-        List<ResGetCategoryDtoV1> result = categoryService.getCategories(
+        PageResponse<ResGetCategoryDtoV1> result = categoryService.getCategories(
                 managerUser.getId(),
-                UserRole.MANAGER.name()
+                UserRole.MANAGER.name(),
+                pageable
         );
 
         // then
-        assertThat(result).isEmpty();
+        // ✅ 수정 (PageResponse 기준)
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isEqualTo(0);
+        assertThat(result.getTotalPages()).isEqualTo(0);
     }
 
     // ============ updateCategory ============

--- a/src/test/java/com/example/whostolemyfood/category/CategoryServiceV1Test.java
+++ b/src/test/java/com/example/whostolemyfood/category/CategoryServiceV1Test.java
@@ -1,131 +1,509 @@
-//package com.example.whostolemyfood.category;
-//
-//import static org.assertj.core.api.Assertions.*;
-//import static org.mockito.BDDMockito.*;
-//
-//import com.example.whostolemyfood.category.application.service.CategoryServiceV1;
-//import com.example.whostolemyfood.category.domain.entity.CategoryEntity;
-//import com.example.whostolemyfood.category.domain.repository.CategoryRepository;
-//import com.example.whostolemyfood.category.presentation.dto.request.ReqCategoryDtoV1;
-//import com.example.whostolemyfood.category.presentation.dto.response.ResGetCategoryDtoV1;
-//import com.example.whostolemyfood.user.application.security.AuthUser;
-//import com.example.whostolemyfood.user.domain.entity.UserEntity;
-//import com.example.whostolemyfood.user.domain.entity.UserRole;
-//import com.example.whostolemyfood.user.domain.repository.UserRepository;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.api.extension.ExtendWith;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.junit.jupiter.MockitoExtension;
-//import org.springframework.test.util.ReflectionTestUtils;
-//
-//import java.util.Optional;
-//import java.util.UUID;
-//
-//@ExtendWith(MockitoExtension.class)
-//class CategoryServiceV1Test {
-//
-//    @Mock
-//    private CategoryRepository categoryRepository;
-//
-//    @Mock
-//    private UserRepository userRepository;
-//
-//    @InjectMocks
-//    private CategoryServiceV1 categoryService;
-//
-//    private UUID userId;
-//    private String userRoleStr = "MASTER";
-//    private UserEntity testUser;
-//
-//    @BeforeEach
-//    void setUp() {
-//        userId = UUID.randomUUID();
-//
-//        // 엔티티의 @Builder 필드명(role, email, password, name)에 맞춰서 생성
-//        testUser = UserEntity.builder()
-//                .role(UserRole.MASTER)
-//                .email("test@example.com")
-//                .password("password")
-//                .name("jieun")
-//                .build();
-//
-//        // 엔티티 필드명이 'id'이므로 "id"로 세팅해야 합니다!
-//        ReflectionTestUtils.setField(testUser, "id", userId);
-//
-//        // BaseAuditEntity나 상속받은 쪽에 isDeleted가 있다면 세팅
-//        // (만약 UserEntity에 isDeleted가 없다면 이 줄은 제외하세요)
-//        // ReflectionTestUtils.setField(testUser, "isDeleted", false);
-//    }
-//
-//    @Test
-//    @DisplayName("카테고리 생성 성공")
-//    void createCategory_success() {
-//        // given
-//        ReqCategoryDtoV1 request = new ReqCategoryDtoV1("한식");
-//        CategoryEntity savedEntity = CategoryEntity.builder()
-//                .categoryId(UUID.randomUUID())
-//                .name("한식")
-//                .build();
-//
-//        given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
-//        given(categoryRepository.save(any(CategoryEntity.class))).willReturn(savedEntity);
-//
-//        // when
-//        ResGetCategoryDtoV1 result = categoryService.createCategory(request, userId, userRoleStr);
-//
-//        // then
-//        assertThat(result.getName()).isEqualTo("한식");
-//        verify(categoryRepository, times(1)).save(any(CategoryEntity.class));
-//    }
-//
-//    // ... getCategory_fail_notFound (이전과 동일)
-//
-//    @Test
-//    @DisplayName("카테고리 이름 수정 성공")
-//    void updateCategory_success() {
-//        // given
-//        UUID categoryId = UUID.randomUUID();
-//        ReqCategoryDtoV1 updateRequest = new ReqCategoryDtoV1("중식");
-//
-//        CategoryEntity existingCategory = CategoryEntity.builder()
-//                .categoryId(categoryId)
-//                .name("한식")
-//                .build();
-//
-//        given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
-//        given(categoryRepository.findByCategoryIdAndIsDeletedFalse(categoryId))
-//                .willReturn(Optional.of(existingCategory));
-//
-//        // when
-//        ResGetCategoryDtoV1 result = categoryService.updateCategory(categoryId, updateRequest, userRoleStr, userId);
-//
-//        // then
-//        assertThat(result.getName()).isEqualTo("중식");
-//    }
-//
-//    @Test
-//    @DisplayName("카테고리 삭제(Soft Delete) 호출 검증")
-//    void deleteCategory_success() {
-//        // given
-//        UUID categoryId = UUID.randomUUID();
-//        CategoryEntity existingCategory = spy(CategoryEntity.builder()
-//                .categoryId(categoryId)
-//                .name("일식")
-//                .build());
-//
-//        ReflectionTestUtils.setField(existingCategory, "isDeleted", false);
-//
-//        given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
-//        given(categoryRepository.findByCategoryIdAndIsDeletedFalse(categoryId))
-//                .willReturn(Optional.of(existingCategory));
-//
-//        // when
-//        categoryService.deleteCategory(categoryId, userRoleStr, userId);
-//
-//        // then
-//        assertThat(existingCategory.getIsDeleted()).isTrue();
-//    }
-//}}
+package com.example.whostolemyfood.category;
+
+import com.example.whostolemyfood.category.application.service.CategoryServiceV1;
+import com.example.whostolemyfood.category.domain.entity.CategoryEntity;
+import com.example.whostolemyfood.category.domain.repository.CategoryRepository;
+import com.example.whostolemyfood.category.presentation.dto.request.ReqCategoryDtoV1;
+import com.example.whostolemyfood.category.presentation.dto.response.ResGetCategoryDtoV1;
+import com.example.whostolemyfood.global.exception.CustomException;
+import com.example.whostolemyfood.global.exception.ErrorCode;
+import com.example.whostolemyfood.user.domain.entity.UserEntity;
+import com.example.whostolemyfood.user.domain.entity.UserRole;
+import com.example.whostolemyfood.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CategoryServiceV1 테스트")
+class CategoryServiceV1Test {
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private CategoryServiceV1 categoryService;
+
+    private UUID testUserId;
+    private UUID testCategoryId;
+    private UserEntity testUser;
+    private UserEntity managerUser;
+    private UserEntity masterUser;
+
+    @BeforeEach
+    void setUp() {
+        testUserId = UUID.randomUUID();
+        testCategoryId = UUID.randomUUID();
+
+        // 일반 사용자 (권한 없음)
+        testUser = UserEntity.builder()
+                .email("user@example.com")
+                .name("일반사용자")
+                .role(UserRole.CUSTOMER)
+                .build();
+        ReflectionTestUtils.setField(testUser, "id", testUserId);
+
+        // 매니저
+        UUID managerId = UUID.randomUUID();
+        managerUser = UserEntity.builder()
+                .email("manager@example.com")
+                .name("매니저")
+                .role(UserRole.MANAGER)
+                .build();
+        ReflectionTestUtils.setField(managerUser, "id", managerId);
+
+        // 마스터
+        UUID masterId = UUID.randomUUID();
+        masterUser = UserEntity.builder()
+                .email("master@example.com")
+                .name("마스터")
+                .role(UserRole.MASTER)
+                .build();
+        ReflectionTestUtils.setField(masterUser, "id", masterId);
+    }
+
+    // ============ createCategory ============
+
+    @Test
+    @DisplayName("정상: 카테고리 생성 성공 - MANAGER")
+    void createCategory_Success_Manager() {
+        // given
+        ReqCategoryDtoV1 request = new ReqCategoryDtoV1("한식");
+
+        given(userRepository.findById(managerUser.getId()))
+                .willReturn(Optional.of(managerUser));
+        given(categoryRepository.existsByNameAndIsDeletedFalse("한식"))
+                .willReturn(false);
+        given(categoryRepository.save(any(CategoryEntity.class)))
+                .willAnswer(invocation -> {
+                    CategoryEntity entity = invocation.getArgument(0);
+                    ReflectionTestUtils.setField(entity, "categoryId", testCategoryId);
+                    return entity;
+                });
+
+        // when
+        ResGetCategoryDtoV1 result = categoryService.createCategory(
+                request,
+                managerUser.getId(),
+                UserRole.MANAGER.name()
+        );
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getName()).isEqualTo("한식");
+        verify(categoryRepository, times(1)).existsByNameAndIsDeletedFalse("한식");
+        verify(categoryRepository, times(1)).save(any(CategoryEntity.class));
+    }
+
+    @Test
+    @DisplayName("정상: 카테고리 생성 성공 - MASTER")
+    void createCategory_Success_Master() {
+        // given
+        ReqCategoryDtoV1 request = new ReqCategoryDtoV1("일식");
+
+        given(userRepository.findById(masterUser.getId()))
+                .willReturn(Optional.of(masterUser));
+        given(categoryRepository.existsByNameAndIsDeletedFalse("일식"))
+                .willReturn(false);
+        given(categoryRepository.save(any(CategoryEntity.class)))
+                .willAnswer(invocation -> {
+                    CategoryEntity entity = invocation.getArgument(0);
+                    ReflectionTestUtils.setField(entity, "categoryId", testCategoryId);
+                    return entity;
+                });
+
+        // when
+        ResGetCategoryDtoV1 result = categoryService.createCategory(
+                request,
+                masterUser.getId(),
+                UserRole.MASTER.name()
+        );
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getName()).isEqualTo("일식");
+        verify(categoryRepository, times(1)).save(any(CategoryEntity.class));
+    }
+
+    @Test
+    @DisplayName("예외: 카테고리 생성 - 중복된 이름")
+    void createCategory_Duplication() {
+        // given
+        ReqCategoryDtoV1 request = new ReqCategoryDtoV1("한식");
+
+        given(userRepository.findById(managerUser.getId()))
+                .willReturn(Optional.of(managerUser));
+        given(categoryRepository.existsByNameAndIsDeletedFalse("한식"))
+                .willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> categoryService.createCategory(
+                request,
+                managerUser.getId(),
+                UserRole.MANAGER.name()
+        )).isInstanceOf(CustomException.class);
+
+        verify(categoryRepository, times(0)).save(any(CategoryEntity.class));
+    }
+
+    @Test
+    @DisplayName("예외: 카테고리 생성 - 사용자를 찾을 수 없음")
+    void createCategory_UserNotFound() {
+        // given
+        ReqCategoryDtoV1 request = new ReqCategoryDtoV1("한식");
+
+        UUID nonExistentId = UUID.randomUUID();
+        given(userRepository.findById(nonExistentId))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> categoryService.createCategory(
+                request,
+                nonExistentId,
+                UserRole.MANAGER.name()
+        )).isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("예외: 활성 카테고리가 이미 존재하면 중복 에러")
+    void createCategory_ActiveCategoryExists_Duplication() {
+        // given
+        ReqCategoryDtoV1 request = new ReqCategoryDtoV1("한식");
+
+        // 활성 카테고리가 이미 존재
+        given(userRepository.findById(managerUser.getId()))
+                .willReturn(Optional.of(managerUser));
+        given(categoryRepository.existsByNameAndIsDeletedFalse("한식"))
+                .willReturn(true);  // 이미 활성 카테고리 존재
+
+        // when & then
+        assertThatThrownBy(() -> categoryService.createCategory(
+                request,
+                managerUser.getId(),
+                UserRole.MANAGER.name()
+        )).isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CATEGORY_DUPLICATION);
+
+        // 저장되면 안됨
+        verify(categoryRepository, times(0)).save(any(CategoryEntity.class));
+    }
+
+    @Test
+    @DisplayName("예외: 카테고리 생성 - 삭제된 사용자")
+    void createCategory_DeletedUser() {
+        // given
+        ReqCategoryDtoV1 request = new ReqCategoryDtoV1("한식");
+
+        UserEntity deletedUser = UserEntity.builder()
+                .email("deleted@example.com")
+                .name("삭제된사용자")
+                .role(UserRole.MANAGER)
+                .build();
+        deletedUser.softDelete();
+        ReflectionTestUtils.setField(deletedUser, "id", managerUser.getId());
+
+        given(userRepository.findById(managerUser.getId()))
+                .willReturn(Optional.of(deletedUser));
+
+        // when & then
+        assertThatThrownBy(() -> categoryService.createCategory(
+                request,
+                managerUser.getId(),
+                UserRole.MANAGER.name()
+        )).isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("예외: 카테고리 생성 - 역할 불일치")
+    void createCategory_RoleMismatch() {
+        // given
+        ReqCategoryDtoV1 request = new ReqCategoryDtoV1("한식");
+
+        given(userRepository.findById(managerUser.getId()))
+                .willReturn(Optional.of(managerUser));
+
+        // when & then (토큰의 역할이 다름)
+        assertThatThrownBy(() -> categoryService.createCategory(
+                request,
+                managerUser.getId(),
+                UserRole.CUSTOMER.name()  // 불일치
+        )).isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ACCESS_DENIED);
+    }
+
+    @Test
+    @DisplayName("예외: 카테고리 생성 - 권한 없음 (CUSTOMER)")
+    void createCategory_NoPermission() {
+        // given
+        ReqCategoryDtoV1 request = new ReqCategoryDtoV1("한식");
+
+        given(userRepository.findById(testUser.getId()))
+                .willReturn(Optional.of(testUser));
+
+        // when & then
+        assertThatThrownBy(() -> categoryService.createCategory(
+                request,
+                testUser.getId(),
+                UserRole.CUSTOMER.name()
+        )).isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ACCESS_DENIED);
+    }
+
+    // ============ getCategory ============
+
+    @Test
+    @DisplayName("정상: 카테고리 상세 조회")
+    void getCategory_Success() {
+        // given
+        CategoryEntity category = CategoryEntity.builder()
+                .name("한식")
+                .build();
+        ReflectionTestUtils.setField(category, "categoryId", testCategoryId);
+
+        given(userRepository.findById(managerUser.getId()))
+                .willReturn(Optional.of(managerUser));
+        given(categoryRepository.findByCategoryIdAndIsDeletedFalse(testCategoryId))
+                .willReturn(Optional.of(category));
+
+        // when
+        ResGetCategoryDtoV1 result = categoryService.getCategory(
+                testCategoryId,
+                managerUser.getId(),
+                UserRole.MANAGER.name()
+        );
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getName()).isEqualTo("한식");
+        verify(categoryRepository, times(1)).findByCategoryIdAndIsDeletedFalse(testCategoryId);
+    }
+
+    @Test
+    @DisplayName("예외: 카테고리 상세 조회 - 존재하지 않음")
+    void getCategory_NotFound() {
+        // given
+        UUID nonExistentId = UUID.randomUUID();
+
+        given(userRepository.findById(managerUser.getId()))
+                .willReturn(Optional.of(managerUser));
+        given(categoryRepository.findByCategoryIdAndIsDeletedFalse(nonExistentId))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> categoryService.getCategory(
+                nonExistentId,
+                managerUser.getId(),
+                UserRole.MANAGER.name()
+        )).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // ============ getCategories ============
+
+    @Test
+    @DisplayName("정상: 카테고리 목록 조회")
+    void getCategories_Success() {
+        // given
+        CategoryEntity category1 = CategoryEntity.builder().name("한식").build();
+        CategoryEntity category2 = CategoryEntity.builder().name("일식").build();
+        CategoryEntity category3 = CategoryEntity.builder().name("중식").build();
+
+        ReflectionTestUtils.setField(category1, "categoryId", UUID.randomUUID());
+        ReflectionTestUtils.setField(category2, "categoryId", UUID.randomUUID());
+        ReflectionTestUtils.setField(category3, "categoryId", UUID.randomUUID());
+
+        given(userRepository.findById(managerUser.getId()))
+                .willReturn(Optional.of(managerUser));
+        given(categoryRepository.findAll())
+                .willReturn(List.of(category1, category2, category3));
+
+        // when
+        List<ResGetCategoryDtoV1> result = categoryService.getCategories(
+                managerUser.getId(),
+                UserRole.MANAGER.name()
+        );
+
+        // then
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).getName()).isEqualTo("한식");
+        assertThat(result.get(1).getName()).isEqualTo("일식");
+        assertThat(result.get(2).getName()).isEqualTo("중식");
+        verify(categoryRepository, times(1)).findAll();
+    }
+
+    @Test
+    @DisplayName("정상: 카테고리 목록 조회 - 빈 결과")
+    void getCategories_Empty() {
+        // given
+        given(userRepository.findById(managerUser.getId()))
+                .willReturn(Optional.of(managerUser));
+        given(categoryRepository.findAll())
+                .willReturn(List.of());
+
+        // when
+        List<ResGetCategoryDtoV1> result = categoryService.getCategories(
+                managerUser.getId(),
+                UserRole.MANAGER.name()
+        );
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    // ============ updateCategory ============
+
+    @Test
+    @DisplayName("정상: 카테고리 수정 성공")
+    void updateCategory_Success() {
+        // given
+        ReqCategoryDtoV1 request = new ReqCategoryDtoV1("한식 (수정됨)");
+
+        CategoryEntity category = CategoryEntity.builder()
+                .name("한식")
+                .build();
+        ReflectionTestUtils.setField(category, "categoryId", testCategoryId);
+
+        given(userRepository.findById(managerUser.getId()))
+                .willReturn(Optional.of(managerUser));
+        given(categoryRepository.findByCategoryIdAndIsDeletedFalse(testCategoryId))
+                .willReturn(Optional.of(category));
+
+        // when
+        ResGetCategoryDtoV1 result = categoryService.updateCategory(
+                testCategoryId,
+                request,
+                managerUser.getId(),
+                UserRole.MANAGER.name()
+        );
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getName()).isEqualTo("한식 (수정됨)");
+        verify(categoryRepository, times(1)).findByCategoryIdAndIsDeletedFalse(testCategoryId);
+    }
+
+    @Test
+    @DisplayName("예외: 카테고리 수정 - 존재하지 않음")
+    void updateCategory_NotFound() {
+        // given
+        ReqCategoryDtoV1 request = new ReqCategoryDtoV1("한식 (수정됨)");
+
+        UUID nonExistentId = UUID.randomUUID();
+        given(userRepository.findById(managerUser.getId()))
+                .willReturn(Optional.of(managerUser));
+        given(categoryRepository.findByCategoryIdAndIsDeletedFalse(nonExistentId))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> categoryService.updateCategory(
+                nonExistentId,
+                request,
+                managerUser.getId(),
+                UserRole.MANAGER.name()
+        )).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("예외: 카테고리 수정 - 권한 없음")
+    void updateCategory_NoPermission() {
+        // given
+        ReqCategoryDtoV1 request = new ReqCategoryDtoV1("한식 (수정됨)");
+
+        given(userRepository.findById(testUser.getId()))
+                .willReturn(Optional.of(testUser));
+
+        // when & then
+        assertThatThrownBy(() -> categoryService.updateCategory(
+                testCategoryId,
+                request,
+                testUser.getId(),
+                UserRole.CUSTOMER.name()
+        )).isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ACCESS_DENIED);
+    }
+
+    // ============ deleteCategory ============
+
+    @Test
+    @DisplayName("정상: 카테고리 삭제 성공")
+    void deleteCategory_Success() {
+        // given
+        CategoryEntity category = CategoryEntity.builder()
+                .name("한식")
+                .build();
+        ReflectionTestUtils.setField(category, "categoryId", testCategoryId);
+
+        given(userRepository.findById(managerUser.getId()))
+                .willReturn(Optional.of(managerUser));
+        given(categoryRepository.findByCategoryIdAndIsDeletedFalse(testCategoryId))
+                .willReturn(Optional.of(category));
+
+        // when
+        categoryService.deleteCategory(
+                testCategoryId,
+                managerUser.getId(),
+                UserRole.MANAGER.name()
+        );
+
+        // then
+        verify(categoryRepository, times(1)).findByCategoryIdAndIsDeletedFalse(testCategoryId);
+        assertThat(category.getIsDeleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("예외: 카테고리 삭제 - 존재하지 않음")
+    void deleteCategory_NotFound() {
+        // given
+        UUID nonExistentId = UUID.randomUUID();
+
+        given(userRepository.findById(managerUser.getId()))
+                .willReturn(Optional.of(managerUser));
+        given(categoryRepository.findByCategoryIdAndIsDeletedFalse(nonExistentId))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> categoryService.deleteCategory(
+                nonExistentId,
+                managerUser.getId(),
+                UserRole.MANAGER.name()
+        )).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("예외: 카테고리 삭제 - 권한 없음")
+    void deleteCategory_NoPermission() {
+        // given
+        given(userRepository.findById(testUser.getId()))
+                .willReturn(Optional.of(testUser));
+
+        // when & then
+        assertThatThrownBy(() -> categoryService.deleteCategory(
+                testCategoryId,
+                testUser.getId(),
+                UserRole.CUSTOMER.name()
+        )).isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ACCESS_DENIED);
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,49 @@
+spring:
+  application:
+    name: Backend
+
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: ${DB_TEST_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+
+  jpa:
+    database: postgresql
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    generate-ddl: true
+    hibernate:
+      ddl-auto: update
+    show_sql: true
+    open-in-view: false
+    properties:
+      hibernate:
+        format_sql: true
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+
+jwt:
+  secret: ${JWT_SECRET}
+  token:
+    access:
+      minute: ${JWT_ACCESS_MINUTE}
+    refresh:
+      minute: ${JWT_REFRESH_MINUTE}
+
+auth:
+  admin-token: ${ADMIN_SIGNUP_TOKEN}
+
+gemini:
+  api-key: ${AI_API_KEY}
+  base-url: ${BASE_URL}
+  model: ${MODEL}
+
+payment:
+  key: ${PAYMENT_KEY}


### PR DESCRIPTION
<br/>

## ✨  제목 : Refactor&Test/#56 category authorization unit test


<br/>

## 🔨 작업 내용

- category entity 수정 
1. GenerationType.UUID 전략
2. name unique 제약 제거

-  Category PageResponse 적용

- Category Repository

- Category Service 

- Category Controller test 코드 작성


  
<br/>

## 🍻  실행된 화면

- PageResponse 반환
<img width="541" height="564" alt="스크린샷 2026-04-28 오전 4 42 58" src="https://github.com/user-attachments/assets/0e48164d-e0b0-4c85-a865-e0147551887b" />

- Category Service Test
<img width="493" height="480" alt="스크린샷 2026-04-28 오전 4 40 16" src="https://github.com/user-attachments/assets/24a71338-160f-4001-bf1b-0d80aaad503b" />

- Category Controller Test
<img width="482" height="313" alt="스크린샷 2026-04-28 오전 4 39 50" src="https://github.com/user-attachments/assets/3a76225c-c454-4d6c-b42a-b4a021c73ce1" />

- Category Repository Test
<img width="487" height="444" alt="스크린샷 2026-04-28 오전 4 39 28" src="https://github.com/user-attachments/assets/80bc326a-ab67-404f-b1a5-6c90897a50c2" />




