### PR TITLE
[Feature] Auth/User 테스트 코드

### DIFF
--- a/src/main/java/com/example/whostolemyfood/user/application/service/UserAdminService.java
+++ b/src/main/java/com/example/whostolemyfood/user/application/service/UserAdminService.java
@@ -1,6 +1,24 @@
 package com.example.whostolemyfood.user.application.service;
 
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import com.example.whostolemyfood.user.presentation.dto.request.ReqManagerCreateDtoV1;
+import com.example.whostolemyfood.user.presentation.dto.response.ResGetUserByIdDtoV1;
+
 public interface UserAdminService {
 
+    //[MASTER 전용] 매니저 생성
+    ResGetUserByIdDtoV1 registerManager(ReqManagerCreateDtoV1 requestDto);
+
+    //[MASTER] 매니저 삭제 (회원 탈퇴 처리)
+    void deleteManager(UUID userId);
+
+    //[MASTER/MANAGER] 단일 사용자 상세 조회
+    ResGetUserByIdDtoV1 getUserById(UUID userId);
+
+    //[MASTER] 전체 사용자 목록 조회 (본인 제외 페이징)
+    Page<ResGetUserByIdDtoV1> findAllUsers(Pageable validatedPageable, UUID myId);
 
 }

--- a/src/main/java/com/example/whostolemyfood/user/presentation/dto/request/ReqManagerCreateDtoV1.java
+++ b/src/main/java/com/example/whostolemyfood/user/presentation/dto/request/ReqManagerCreateDtoV1.java
@@ -3,12 +3,11 @@ package com.example.whostolemyfood.user.presentation.dto.request;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+
+import lombok.*;
 
 @Getter
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class ReqManagerCreateDtoV1 {

--- a/src/main/java/com/example/whostolemyfood/user/presentation/dto/response/ResGetUserByIdDtoV1.java
+++ b/src/main/java/com/example/whostolemyfood/user/presentation/dto/response/ResGetUserByIdDtoV1.java
@@ -3,10 +3,12 @@ package com.example.whostolemyfood.user.presentation.dto.response;
 import com.example.whostolemyfood.user.domain.entity.UserEntity;
 import com.example.whostolemyfood.user.domain.entity.UserRole;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class ResGetUserByIdDtoV1 {

--- a/src/test/java/com/example/whostolemyfood/auth/AuthControllerTest.java
+++ b/src/test/java/com/example/whostolemyfood/auth/AuthControllerTest.java
@@ -23,12 +23,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 // 2. 결과 검증 (status, jsonPath용)
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 // 3. Mockito 설정 (given, any용)
 import static org.mockito.BDDMockito.given;
 import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(AuthControllerV1.class)
 @Import(GlobalExceptionHandler.class)
@@ -71,5 +70,28 @@ public class AuthControllerTest {
     }
 
     @Test
-    public void logout() throws Exception {}
+    @DisplayName("로그아웃 성공 테스트")
+    public void logout_success() throws Exception {
+        // 컨트롤러에서 AuthUser를 사용하므로, ArgumentMatchers나 Security 설정을 타야 하지만
+        // addFilters = false 상태에서는 Principal이 null로 들어올 수 있습니다.
+        // 이 경우 @AuthenticationPrincipal을 모킹하거나 void 메서드 호출을 확인합니다.
+
+        // 1. 실행 및 검증
+        mockMvc.perform(post("/api/v1/auth/logout")
+                        // SecurityContext에 유저가 있다고 가정하거나 필터를 껐으므로
+                        // 실제 AuthUser 객체 주입은 테스트 환경 설정에 따라 다를 수 있음
+                        .principal(() -> TEST_USER_ID.toString()))
+                .andExpect(status().isOk())
+                .andExpect(content().string("로그아웃 성공"));
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 성공 테스트")
+    public void signout_success() throws Exception {
+        // 1. 실행 및 검증
+        mockMvc.perform(post("/api/v1/auth/signout")
+                        .principal(() -> TEST_USER_ID.toString()))
+                .andExpect(status().isOk())
+                .andExpect(content().string("회원 탈퇴 완료"));
+    }
 }

--- a/src/test/java/com/example/whostolemyfood/auth/AuthServiceTest.java
+++ b/src/test/java/com/example/whostolemyfood/auth/AuthServiceTest.java
@@ -1,0 +1,155 @@
+package com.example.whostolemyfood.auth;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.example.whostolemyfood.auth.application.service.AuthServiceV1;
+import com.example.whostolemyfood.auth.presentation.dto.request.ReqLoginDtoV1;
+import com.example.whostolemyfood.auth.presentation.dto.request.ReqSignUpDtoV1;
+import com.example.whostolemyfood.auth.presentation.dto.response.ResLoginDtoV1;
+import com.example.whostolemyfood.auth.presentation.dto.response.ResSignUpDtoV1;
+import com.example.whostolemyfood.global.config.security.jwt.JwtUtil;
+import com.example.whostolemyfood.global.exception.CustomException;
+import com.example.whostolemyfood.global.exception.ErrorCode;
+import com.example.whostolemyfood.user.domain.entity.UserEntity;
+import com.example.whostolemyfood.user.domain.entity.UserRole;
+import com.example.whostolemyfood.user.domain.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthServiceTest {
+
+    @InjectMocks
+    private AuthServiceV1 authService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    private final String 가짜_어드민_토큰 = "test-admin-secret";
+
+    @BeforeEach
+    void 설정() {
+
+        ReflectionTestUtils.setField(authService, "adminSecretKey", 가짜_어드민_토큰);
+    }
+
+    @Test
+    @DisplayName("회원가입 성공 - 일반 고객(CUSTOMER) 권한")
+    void 회원가입_성공() {
+        // 1. 준비
+        ReqSignUpDtoV1 요청 = ReqSignUpDtoV1.builder()
+                .email("soyoon@test.com")
+                .password("password123")
+                .userName("소윤")
+                .userRole(UserRole.CUSTOMER)
+                .build();
+
+        given(userRepository.existsByUserEmail(anyString())).willReturn(false);
+        given(passwordEncoder.encode(anyString())).willReturn("encoded-pw");
+
+        // 2. 실행
+        ResSignUpDtoV1 결과 = authService.signup(요청);
+
+        // 3. 검증
+        assertThat(결과.getEmail()).isEqualTo("soyoon@test.com");
+        assertThat(결과.getUserName()).isEqualTo("소윤");
+        // 실제로 DB 저장 메서드가 호출되었는지 확인
+        verify(userRepository, times(1)).save(any(UserEntity.class));
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - 이메일 중복")
+    void 회원가입_실패_중복_이메일() {
+        // 1. 준비
+        ReqSignUpDtoV1 요청 = ReqSignUpDtoV1.builder()
+                .email("duplicate@test.com")
+                .userRole(UserRole.CUSTOMER)
+                .build();
+
+        given(userRepository.existsByUserEmail(anyString())).willReturn(true);
+
+        // 2. 실행 및 검증
+        assertThatThrownBy(() -> authService.signup(요청))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_DUPLICATION_EMAIL);
+    }
+
+    @Test
+    @DisplayName("로그인 성공 - 토큰 발급 확인")
+    void 로그인_성공() {
+        // 1. 준비
+        UUID 유저_ID = UUID.randomUUID();
+        ReqLoginDtoV1 요청 = new ReqLoginDtoV1("soyoon@test.com", "password123");
+
+        UserEntity 가짜_유저 = UserEntity.builder()
+                .email("soyoon@test.com")
+                .password("encoded-pw")
+                .role(UserRole.CUSTOMER)
+                .build();
+        ReflectionTestUtils.setField(가짜_유저, "id", 유저_ID);
+
+        given(userRepository.findByUserEmail(anyString())).willReturn(Optional.of(가짜_유저));
+        given(passwordEncoder.matches(anyString(), anyString())).willReturn(true);
+        given(jwtUtil.createToken(any(UUID.class), any(UserRole.class))).willReturn("fake-access-token");
+
+        // 2. 실행
+        ResLoginDtoV1 결과 = authService.login(요청);
+
+        // 3. 검증
+        assertThat(결과.getUserId()).isEqualTo(유저_ID);
+        assertThat(결과.getAccessToken()).isEqualTo("fake-access-token");
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 비밀번호 불일치")
+    void 로그인_실패_비밀번호_틀림() {
+        // 1. 준비
+        ReqLoginDtoV1 요청 = new ReqLoginDtoV1("soyoon@test.com", "wrong-pw");
+        UserEntity 가짜_유저 = UserEntity.builder()
+                .email("soyoon@test.com")
+                .password("encoded-pw")
+                .build();
+
+        given(userRepository.findByUserEmail(anyString())).willReturn(Optional.of(가짜_유저));
+        given(passwordEncoder.matches(anyString(), anyString())).willReturn(false);
+
+        // 2. 실행 및 검증
+        assertThatThrownBy(() -> authService.login(요청))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_WRONG_PW);
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - 관리자 토큰 불일치 (MASTER 권한 시도)")
+    void 회원가입_실패_어드민토큰_오류() {
+        // 1. 준비
+        ReqSignUpDtoV1 요청 = ReqSignUpDtoV1.builder()
+                .email("master@test.com")
+                .userRole(UserRole.MASTER)
+                .adminToken("wrong-secret-key") // 잘못된 토큰 입력
+                .build();
+
+        // 2. 실행 및 검증
+        assertThatThrownBy(() -> authService.signup(요청))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ACCESS_DENIED);
+    }
+}

--- a/src/test/java/com/example/whostolemyfood/user/UserAdminControllerTest.java
+++ b/src/test/java/com/example/whostolemyfood/user/UserAdminControllerTest.java
@@ -1,0 +1,118 @@
+package com.example.whostolemyfood.user;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.example.whostolemyfood.global.exception.GlobalExceptionHandler;
+import com.example.whostolemyfood.user.application.service.UserAdminServiceV1;
+import com.example.whostolemyfood.user.presentation.controller.UserAdminControllerV1;
+import com.example.whostolemyfood.user.presentation.dto.request.ReqManagerCreateDtoV1;
+import com.example.whostolemyfood.user.presentation.dto.response.ResGetUserByIdDtoV1;
+import com.example.whostolemyfood.user.domain.entity.UserRole;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Import;
+
+@WebMvcTest(UserAdminControllerV1.class)
+@Import(GlobalExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false) // @PreAuthorize 검증은 실제 서버에서 하고, 여기선 로직 위주로 테스트
+public class UserAdminControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private UserAdminServiceV1 userAdminService;
+
+    private final UUID 관리자_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+    private final UUID 대상_유저_ID = UUID.fromString("660e8400-e29b-41d4-a716-446655441111");
+
+    @Test
+    @DisplayName("전체 사용자 목록 조회 성공 테스트 (본인 제외)")
+    void 전체_사용자_조회_성공() throws Exception {
+        // 1. 준비 (Given)
+        ResGetUserByIdDtoV1 유저1 = ResGetUserByIdDtoV1.builder()
+                .email("user1@test.com").name("유저1").role(UserRole.CUSTOMER).build();
+        PageImpl<ResGetUserByIdDtoV1> 페이지_결과 = new PageImpl<>(List.of(유저1), PageRequest.of(0, 10), 1);
+
+        given(userAdminService.findAllUsers(any(Pageable.class), any(UUID.class))).willReturn(페이지_결과);
+
+        // 2. 실행 및 검증
+        mockMvc.perform(get("/api/v1/admin/users")
+                        .principal(() -> 관리자_ID.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].email").value("user1@test.com"))
+                .andExpect(jsonPath("$.totalElements").value(1));
+    }
+
+    @Test
+    @DisplayName("특정 사용자 상세 조회 성공 테스트")
+    void 사용자_상세_조회_성공() throws Exception {
+        // 1. 준비
+        ResGetUserByIdDtoV1 응답 = ResGetUserByIdDtoV1.builder()
+                .email("target@test.com").name("대상유저").role(UserRole.CUSTOMER).build();
+
+        given(userAdminService.getUserById(대상_유저_ID)).willReturn(응답);
+
+        // 2. 실행 및 검증
+        mockMvc.perform(get("/api/v1/admin/users/{userId}", 대상_유저_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value("target@test.com"));
+    }
+
+    @Test
+    @DisplayName("[MASTER] 매니저 생성 성공 테스트")
+    void 매니저_생성_성공() throws Exception {
+        // 1. 준비
+        ReqManagerCreateDtoV1 요청 = new ReqManagerCreateDtoV1("manager@test.com", "pw123", "매니저", "admin-token");
+        ResGetUserByIdDtoV1 응답 = ResGetUserByIdDtoV1.builder()
+                .email("manager@test.com").name("매니저").role(UserRole.MANAGER).build();
+
+        given(userAdminService.registerManager(any(ReqManagerCreateDtoV1.class))).willReturn(응답);
+
+        // 2. 실행 및 검증
+        mockMvc.perform(post("/api/v1/admin/users/managers")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(요청)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.role").value("MANAGER"));
+    }
+
+    @Test
+    @DisplayName("[MASTER] 매니저 삭제 성공 테스트")
+    void 매니저_삭제_성공() throws Exception {
+        // 1. 실행 및 검증
+        mockMvc.perform(delete("/api/v1/admin/users/managers/{userId}", 대상_유저_ID)
+                        .principal(() -> 관리자_ID.toString()))
+                .andExpect(status().isNoContent());
+
+        verify(userAdminService, times(1)).deleteManager(대상_유저_ID);
+    }
+
+    @Test
+    @DisplayName("본인 계정 삭제 시도 시 예외 발생 테스트")
+    void 본인_삭제_차단_테스트() throws Exception {
+        // 2. 실행 및 검증 (본인의 ID로 삭제 요청)
+        mockMvc.perform(delete("/api/v1/admin/users/managers/{userId}", 관리자_ID)
+                        .principal(() -> 관리자_ID.toString()))
+                .andExpect(status().isForbidden()); // 에러 코드에 따라 status는 달라질 수 있음 (GlobalExceptionHandler 기준)
+    }
+}

--- a/src/test/java/com/example/whostolemyfood/user/UserAdminServiceTest.java
+++ b/src/test/java/com/example/whostolemyfood/user/UserAdminServiceTest.java
@@ -1,0 +1,121 @@
+package com.example.whostolemyfood.user;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import com.example.whostolemyfood.auth.application.service.AuthService;
+import com.example.whostolemyfood.auth.presentation.dto.response.ResSignUpDtoV1;
+import com.example.whostolemyfood.user.application.service.UserAdminServiceV1;
+import com.example.whostolemyfood.user.domain.entity.UserEntity;
+import com.example.whostolemyfood.user.domain.entity.UserRole;
+import com.example.whostolemyfood.user.domain.repository.UserRepository;
+import com.example.whostolemyfood.user.presentation.dto.request.ReqManagerCreateDtoV1;
+import com.example.whostolemyfood.user.presentation.dto.response.ResGetUserByIdDtoV1;
+
+@ExtendWith(MockitoExtension.class)
+public class UserAdminServiceTest {
+
+    @InjectMocks
+    private UserAdminServiceV1 userAdminService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private AuthService authService;
+
+    private final UUID 관리자_ID = UUID.randomUUID();
+    private final UUID 대상_유저_ID = UUID.randomUUID();
+
+    @Test
+    @DisplayName("매니저 등록 성공 - AuthService 재사용 확인")
+    void 매니저_등록_성공() {
+        // 1. 준비 (Given)
+        ReqManagerCreateDtoV1 요청 = new ReqManagerCreateDtoV1("manager@test.com", "pw123", "매니저", "admin-token");
+        ResSignUpDtoV1 인증서비스_응답 = new ResSignUpDtoV1("manager@test.com", "매니저");
+
+        UserEntity 저장된_매니저 = UserEntity.builder()
+                .email("manager@test.com")
+                .name("매니저")
+                .role(UserRole.MANAGER)
+                .build();
+
+        // authService.signup 호출 시 응답 설정
+        given(authService.signup(any())).willReturn(인증서비스_응답);
+        // userRepository 조회 시 응답 설정
+        given(userRepository.findByUserEmail(anyString())).willReturn(Optional.of(저장된_매니저));
+
+        // 2. 실행 (When)
+        ResGetUserByIdDtoV1 결과 = userAdminService.registerManager(요청);
+
+        // 3. 검증 (Then)
+        assertThat(결과.getEmail()).isEqualTo("manager@test.com");
+        assertThat(결과.getRole()).isEqualTo(UserRole.MANAGER);
+
+        // AuthService의 signup이 정확히 한 번 호출되었는지 확인
+        verify(authService, times(1)).signup(any());
+    }
+
+    @Test
+    @DisplayName("전체 사용자 목록 조회 - 본인 제외 페이징 확인")
+    void 전체_사용자_조회_성공() {
+        // 1. 준비
+        Pageable 페이지_요청 = PageRequest.of(0, 10);
+        UserEntity 유저1 = UserEntity.builder().email("user1@test.com").name("유저1").role(UserRole.CUSTOMER).build();
+        Page<UserEntity> 페이지_결과 = new PageImpl<>(List.of(유저1), 페이지_요청, 1);
+
+        given(userRepository.findAllExceptMe(페이지_요청, 관리자_ID)).willReturn(페이지_결과);
+
+        // 2. 실행
+        Page<ResGetUserByIdDtoV1> 결과 = userAdminService.findAllUsers(페이지_요청, 관리자_ID);
+
+        // 3. 검증
+        assertThat(결과.getContent()).hasSize(1);
+        assertThat(결과.getContent().get(0).getEmail()).isEqualTo("user1@test.com");
+        verify(userRepository, times(1)).findAllExceptMe(any(), any());
+    }
+
+    @Test
+    @DisplayName("매니저 삭제 - AuthService.signout 호출 확인")
+    void 매니저_삭제_성공() {
+        // 1. 실행
+        userAdminService.deleteManager(대상_유저_ID);
+
+        // 2. 검증
+        verify(authService, times(1)).signout(대상_유저_ID);
+    }
+
+    @Test
+    @DisplayName("사용자 상세 조회 성공")
+    void 사용자_상세_조회_성공() {
+        // 1. 준비
+        UserEntity 유저 = UserEntity.builder()
+                .email("detail@test.com")
+                .name("상세유저")
+                .role(UserRole.CUSTOMER)
+                .build();
+        given(userRepository.findById(대상_유저_ID)).willReturn(Optional.of(유저));
+
+        // 2. 실행
+        ResGetUserByIdDtoV1 결과 = userAdminService.getUserById(대상_유저_ID);
+
+        // 3. 검증
+        assertThat(결과.getEmail()).isEqualTo("detail@test.com");
+        assertThat(결과.getName()).isEqualTo("상세유저");
+    }
+}

--- a/src/test/java/com/example/whostolemyfood/user/UserControllerTest.java
+++ b/src/test/java/com/example/whostolemyfood/user/UserControllerTest.java
@@ -1,0 +1,99 @@
+package com.example.whostolemyfood.user;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.example.whostolemyfood.global.exception.GlobalExceptionHandler;
+import com.example.whostolemyfood.user.application.service.UserService;
+import com.example.whostolemyfood.user.domain.entity.UserRole;
+import com.example.whostolemyfood.user.presentation.controller.UserControllerV1;
+import com.example.whostolemyfood.user.presentation.dto.request.ReqUpdateUserDtoV1;
+import com.example.whostolemyfood.user.presentation.dto.response.ResGetUserByIdDtoV1;
+import com.example.whostolemyfood.user.presentation.dto.response.ResUpdateUserDtoV1;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Import;
+
+@WebMvcTest(UserControllerV1.class)
+@Import(GlobalExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false) // 시큐리티 필터는 일단 끄고 진행합니다.
+public class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private UserService userService;
+
+    // 테스트에 사용할 고정 UUID
+    private final UUID 테스트_유저_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+
+    @Test
+    @DisplayName("내 정보 조회 성공 테스트 - 이메일, 이름, 역할 확인")
+    void 내_정보_조회_성공() throws Exception {
+        // 1. 준비 (Given)
+        ResGetUserByIdDtoV1 응답_DTO = new ResGetUserByIdDtoV1(
+                "whostolemyfood@test.com",
+                "whostolemyfood1",
+                com.example.whostolemyfood.user.domain.entity.UserRole.CUSTOMER
+        );
+
+        given(userService.getUserById(any(UUID.class))).willReturn(응답_DTO);
+
+        // 2. 실행 (When) & 검증 (Then)
+        mockMvc.perform(get("/api/v1/user/me")
+                        .principal(() -> 테스트_유저_ID.toString()))
+                .andExpect(status().isOk())
+                // JSON 응답 필드 검증
+                .andExpect(jsonPath("$.email").value("whostolemyfood@test.com"))
+                .andExpect(jsonPath("$.name").value("whostolemyfood"))
+                .andExpect(jsonPath("$.role").value("CUSTOMER")); // Enum은 문자열로 비교
+    }
+
+    @Test
+    @DisplayName("내 정보 수정 성공 테스트 - 이름, 비밀번호, 주소 변경")
+    void 내_정보_수정_성공() throws Exception {
+        // 1. 준비
+        ReqUpdateUserDtoV1 요청_DTO = new ReqUpdateUserDtoV1();
+        org.springframework.test.util.ReflectionTestUtils.setField(요청_DTO, "name", "whostolemyfood수정수정");
+        org.springframework.test.util.ReflectionTestUtils.setField(요청_DTO, "password", "new-password-123");
+        org.springframework.test.util.ReflectionTestUtils.setField(요청_DTO, "address", "서울시 강남구");
+
+        // 서비스 응답 가짜 데이터 생성
+        ResUpdateUserDtoV1 응답_DTO = ResUpdateUserDtoV1.builder()
+                .email("soyoon@test.com")
+                .name("whostolemyfood수정수정")
+                .role(com.example.whostolemyfood.user.domain.entity.UserRole.CUSTOMER)
+                .message("회원 정보 및 주소가 수정되었습니다.")
+                .build();
+
+        given(userService.updateUser(any(UUID.class), any(ReqUpdateUserDtoV1.class)))
+                .willReturn(응답_DTO);
+
+        // 2. 실행 (When) & 검증 (Then)
+        mockMvc.perform(patch("/api/v1/user/me")
+                        .principal(() -> 테스트_유저_ID.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(요청_DTO)))
+                .andExpect(status().isOk())
+                // JSON 응답 필드 검증
+                .andExpect(jsonPath("$.email").value("whostolemyfood@test.com"))
+                .andExpect(jsonPath("$.name").value("whostolemyfood수정수정"))
+                .andExpect(jsonPath("$.role").value("CUSTOMER"))
+                .andExpect(jsonPath("$.message").value("회원 정보 및 주소가 수정되었습니다."));
+    }
+}

--- a/src/test/java/com/example/whostolemyfood/user/UserRepositoryTest.java
+++ b/src/test/java/com/example/whostolemyfood/user/UserRepositoryTest.java
@@ -1,0 +1,90 @@
+package com.example.whostolemyfood.user;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import com.example.whostolemyfood.user.domain.entity.UserEntity;
+import com.example.whostolemyfood.user.domain.entity.UserRole;
+import com.example.whostolemyfood.user.domain.repository.UserRepository;
+import com.example.whostolemyfood.user.infrastructure.repository.UserRepositoryImpl;
+
+@DataJpaTest
+@Import(UserRepositoryImpl.class) // QueryDSL이나 커스텀 레포 구현체를 쓰면 임포트가 필요합니다.
+public class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("나를 제외한 전체 사용자 목록 조회 (소프트 딜리트 제외 확인)")
+    void 전체_사용자_조회_성공() {
+        // 1. 준비
+        UserEntity 나 = UserEntity.builder()
+                .email("me@test.com").name("소윤").role(UserRole.MASTER).build();
+        UserEntity 유저1 = UserEntity.builder()
+                .email("user1@test.com").name("유저1").role(UserRole.CUSTOMER).build();
+
+        userRepository.save(나);
+        userRepository.save(유저1);
+        // save 후에는 영속성 컨텍스트를 비우거나 flush해서 ID를 확정짓는게 안전해요.
+        userRepository.flush();
+
+        // 2. 실행
+        Page<UserEntity> 결과 = userRepository.findAllExceptMe(PageRequest.of(0, 10), 나.getId());
+
+        // 3. 검증 (더 안전한 방식)
+        assertThat(결과.getContent()).isNotEmpty(); // 우선 비어있지 않은지 확인
+        assertThat(결과.getTotalElements()).isEqualTo(1); // 나를 제외한 1명만 있어야 함
+
+        // 이메일 리스트를 추출해서 "user1@test.com"이 포함되어 있는지 확인
+        assertThat(결과.getContent())
+                .extracting(UserEntity::getUserEmail)
+                .containsExactly("user1@test.com");
+    }
+
+    @Test
+    @DisplayName("이메일로 유저 찾기 - 활성 유저만")
+    void 이메일_조회_테스트() {
+        // 1. 준비
+        String targetEmail = "findme@test.com";
+        UserEntity 유저 = UserEntity.builder()
+                .email(targetEmail)
+                .name("조회대상")
+                .role(UserRole.CUSTOMER)
+                .build();
+        userRepository.saveAndFlush(유저); // 즉시 반영
+
+        // 2. 실행
+        Optional<UserEntity> 결과 = userRepository.findByUserEmail(targetEmail);
+
+        // 3. 검증
+        assertThat(결과).isPresent(); // 비어있으면 여기서 실패 메시지가 명확히 나옴
+        assertThat(결과.get().getUserName()).isEqualTo("조회대상");
+    }
+
+    @Test
+    @DisplayName("findByIdAndIsDeletedFalse - 삭제된 유저는 조회되지 않아야 함")
+    void 소프트딜리트_조회_제한_테스트() {
+        // 1. 준비
+        UserEntity 삭제된_유저 = UserEntity.builder()
+                .email("hidden@test.com").name("비공개").role(UserRole.CUSTOMER).build();
+        org.springframework.test.util.ReflectionTestUtils.setField(삭제된_유저, "isDeleted", true);
+        userRepository.save(삭제된_유저);
+
+        // 2. 실행
+        java.util.Optional<UserEntity> 결과 = userRepository.findByIdAndIsDeletedFalse(삭제된_유저.getId());
+
+        // 3. 검증
+        assertThat(결과).isEmpty();
+    }
+}

--- a/src/test/java/com/example/whostolemyfood/user/UserServiceTest.java
+++ b/src/test/java/com/example/whostolemyfood/user/UserServiceTest.java
@@ -1,0 +1,127 @@
+package com.example.whostolemyfood.user;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.example.whostolemyfood.global.exception.CustomException;
+import com.example.whostolemyfood.global.exception.ErrorCode;
+import com.example.whostolemyfood.user.application.service.UserServiceV1;
+import com.example.whostolemyfood.user.domain.entity.UserEntity;
+import com.example.whostolemyfood.user.domain.entity.UserRole;
+import com.example.whostolemyfood.user.domain.repository.UserRepository;
+import com.example.whostolemyfood.user.presentation.dto.request.ReqUpdateUserDtoV1;
+import com.example.whostolemyfood.user.presentation.dto.response.ResGetUserByIdDtoV1;
+import com.example.whostolemyfood.user.presentation.dto.response.ResUpdateUserDtoV1;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+
+    @InjectMocks
+    private UserServiceV1 userService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    private final UUID 테스트_유저_ID = UUID.randomUUID();
+
+    @Test
+    @DisplayName("유저 조회 성공 - 활성 상태 유저")
+    void 유저_조회_성공() {
+        // 1. 준비
+        UserEntity 가짜_유저 = UserEntity.builder()
+                .email("whostolemyFood.com")
+                .name("whostolemyFood1")
+                .role(UserRole.CUSTOMER)
+                .build();
+        ReflectionTestUtils.setField(가짜_유저, "isDeleted", false);
+
+        given(userRepository.findById(테스트_유저_ID)).willReturn(Optional.of(가짜_유저));
+
+        // 2. 실행 (When)
+        ResGetUserByIdDtoV1 결과 = userService.getUserById(테스트_유저_ID);
+
+        // 3. 검증 (Then)
+        assertThat(결과.getEmail()).isEqualTo("whostolemyFood@test.com");
+        assertThat(결과.getName()).isEqualTo("whostolemyFood1");
+    }
+
+    @Test
+    @DisplayName("유저 조회 실패 - 삭제된 유저인 경우")
+    void 유저_조회_실패_삭제됨() {
+        // 1. 준비
+        UserEntity 삭제된_유저 = UserEntity.builder().build();
+        ReflectionTestUtils.setField(삭제된_유저, "isDeleted", true); // 삭제 상태로 세팅
+
+        given(userRepository.findById(테스트_유저_ID)).willReturn(Optional.of(삭제된_유저));
+
+        // 2. 실행 및 검증
+        assertThatThrownBy(() -> userService.getUserById(테스트_유저_ID))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("유저 정보 수정 성공 - 비밀번호 포함 변경")
+    void 유저_정보_수정_성공() {
+        // 1. 준비
+        ReqUpdateUserDtoV1 요청 = new ReqUpdateUserDtoV1();
+        ReflectionTestUtils.setField(요청, "name", "whostolemyFood수정");
+        ReflectionTestUtils.setField(요청, "password", "new-pw");
+        ReflectionTestUtils.setField(요청, "address", "서울시 강남구");
+
+        UserEntity 기존_유저 = UserEntity.builder()
+                .email("whostolemyFood@test.com")
+                .name("whostolemyFood1")
+                .password("old-pw")
+                .role(UserRole.CUSTOMER)
+                .build();
+        ReflectionTestUtils.setField(기존_유저, "isDeleted", false);
+
+        given(userRepository.findById(테스트_유저_ID)).willReturn(Optional.of(기존_유저));
+        given(passwordEncoder.encode("new-pw")).willReturn("encoded-new-pw");
+
+        // 2. 실행
+        ResUpdateUserDtoV1 결과 = userService.updateUser(테스트_유저_ID, 요청);
+
+        // 3. 검증
+        assertThat(결과.getName()).isEqualTo("whostolemyFood수정수정");
+        assertThat(결과.getMessage()).contains("성공적으로 수정");
+        verify(passwordEncoder, times(1)).encode(anyString());
+    }
+
+    @Test
+    @DisplayName("유저 정보 수정 - 비밀번호 미포함 시 인코딩 건너뛰기")
+    void 유저_수정_비밀번호_없음() {
+        // 1. 준비
+        ReqUpdateUserDtoV1 요청 = new ReqUpdateUserDtoV1();
+        ReflectionTestUtils.setField(요청, "name", "이름만수정");
+        // password는 세팅 안함 (null 혹은 공백)
+
+        UserEntity 기존_유저 = UserEntity.builder().role(UserRole.CUSTOMER).build();
+        ReflectionTestUtils.setField(기존_유저, "isDeleted", false);
+
+        given(userRepository.findById(테스트_유저_ID)).willReturn(Optional.of(기존_유저));
+
+        // 2. 실행
+        userService.updateUser(테스트_유저_ID, 요청);
+
+        // 3. 검증
+        // passwordEncoder.encode 가 한 번도 호출되지 않아야 함
+        verify(passwordEncoder, never()).encode(anyString());
+    }
+}


### PR DESCRIPTION
## 🔨 작업 내용

- Auth Service 레이어 검증
회원가입 시 이메일 중복 체크, 관리자 토큰 검증, 로그인 시 비밀번호 일치 여부 등 비즈니스 로직 단위 테스트 완료

-User API 슬라이스 테스트
MockMvc를 활용하여 내 정보 조회, 정보 수정 API 검증

-Admin 관리 기능 보안 검증
매니저 생성 및 삭제 로직 검증, 특히 관리자가 본인 계정을 삭제/상태 변경하려 할 때 예외가 정상적으로 발생하는지 2중 보안 로직 테스트

-Repository 커스텀 쿼리 테스트
  
<br/>

## 🍻  실행된 화면(postman에서 테스트한 것 캡쳐해서 올려주세요 성공, 예외처리되는것까지)

- 

<br/>

## 🔎   앞으로의 과제

- Redis 기반 로그아웃 블랙리스트 구현: 현재 TODO로 남겨둔 로그아웃 시 Redis를 활용한 토큰 무효화 로직 추가 예정

- Refresh Token 도입: 보안 강화를 위해 리프레시 토큰 발급 및 재발급 로직 구현 및 테스트 추가


  <br/>

  풀리퀘 후 오른쪽에서 assign, reviewer, label 붙이는거 잊지마세요!!!(중요)
