### PR TITLE
feat & refactor: Swagger 설정 및 API 문서화 menuService 리펙토링

### DIFF
--- a/src/main/java/com/example/whostolemyfood/address/presentation/controller/AddressControllerV1.java
+++ b/src/main/java/com/example/whostolemyfood/address/presentation/controller/AddressControllerV1.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.converters.models.PageableAsQueryParam;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -24,7 +25,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
-@Tag(name = "Address API", description = "배송지 관리 API")
+@Tag(name = "Address API", description = "사용자 배송지 관리 API")
 @RestController
 @RequestMapping("/api/v1/addresses")
 @RequiredArgsConstructor
@@ -33,7 +34,7 @@ public class AddressControllerV1 {
 
     private final AddressServiceV1 addressService;
 
-    @Operation(summary = "배송지 생성", description = "로그인한 사용자의 새로운 배송지를 생성합니다.")
+    @Operation(summary = "배송지 생성", description = "[CUSTOMER] 로그인한 사용자의 새로운 배송지를 생성합니다.")
     @PostMapping
     @PreAuthorize("hasAnyRole('CUSTOMER')")
     public ResponseEntity<ResCreateAddressDtoV1> createAddress(
@@ -42,7 +43,8 @@ public class AddressControllerV1 {
         return ResponseEntity.ok(addressService.createAddress(request, authUser.userId(), authUser.role()));
     }
 
-    @Operation(summary = "본인 배송지 목록 조회", description = "로그인한 사용자의 배송지 목록을 조회합니다. 별칭으로 검색이 가능합니다.")
+    @Operation(summary = "본인 배송지 목록 조회", description = "[CUSTOMER] 로그인한 사용자의 배송지 목록을 조회합니다. 별칭으로 검색이 가능합니다.")
+    @PageableAsQueryParam
     @GetMapping
     @PreAuthorize("hasAnyRole('CUSTOMER')")
     public ResponseEntity<PageResponse<ResGetAddressDtoV1>> getMyAddresses(
@@ -56,7 +58,7 @@ public class AddressControllerV1 {
         return ResponseEntity.ok(new PageResponse<>(addresses));
     }
 
-    @Operation(summary = "배송지 수정", description = "특정 배송지의 정보를 수정합니다. 본인의 배송지만 수정 가능합니다.")
+    @Operation(summary = "배송지 수정", description = "[CUSTOMER] 특정 배송지의 정보를 수정합니다. 본인의 배송지만 수정 가능합니다.")
     @PutMapping("/{addressId}")
     @PreAuthorize("hasAnyRole('CUSTOMER')")
     public ResponseEntity<ResGetAddressDtoV1> updateAddress(
@@ -66,7 +68,7 @@ public class AddressControllerV1 {
         return ResponseEntity.ok(addressService.updateAddress(addressId, request, authUser.userId(), authUser.role()));
     }
 
-    @Operation(summary = "배송지 삭제", description = "특정 배송지를 삭제(Soft Delete) 처리합니다. 본인의 배송지만 삭제 가능합니다.")
+    @Operation(summary = "배송지 삭제", description = "[CUSTOMER] 특정 배송지를 삭제(Soft Delete) 처리합니다. 본인의 배송지만 삭제 가능합니다.")
     @DeleteMapping("/{addressId}")
     @PreAuthorize("hasAnyRole('CUSTOMER')")
     public ResponseEntity<Void> deleteAddress(

--- a/src/main/java/com/example/whostolemyfood/address/presentation/dto/request/ReqCreateAddressDtoV1.java
+++ b/src/main/java/com/example/whostolemyfood/address/presentation/dto/request/ReqCreateAddressDtoV1.java
@@ -1,26 +1,33 @@
 package com.example.whostolemyfood.address.presentation.dto.request;
 
 import com.example.whostolemyfood.address.domain.entity.AddressEntity;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
 import java.util.UUID;
 
 @Getter
+@Schema(description = "배송지 등록 요청 객체")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class ReqCreateAddressDtoV1 {
 
+    @Schema(description = "별칭", example = "우리집")
     private String alias;
 
+    @Schema(description = "주소", example = "서울특별시 종로구 세종대로 172")
     @NotBlank(message = "배송지 주소는 필수 입력 사항입니다.")
     private String address;
 
+    @Schema(description = "상세주소", example = "세종대왕 상 앞")
     private String detail;
 
+    @Schema(description = "우편번호", example = "11182")
     private String zipCode;
 
+    @Schema(description = "기본 배송지 여부", example = "false")
     private Boolean isDefault;
 
     public AddressEntity toEntity(UUID userId) {

--- a/src/main/java/com/example/whostolemyfood/address/presentation/dto/request/ReqUpdateAddressDtoV1.java
+++ b/src/main/java/com/example/whostolemyfood/address/presentation/dto/request/ReqUpdateAddressDtoV1.java
@@ -1,22 +1,29 @@
 package com.example.whostolemyfood.address.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
 @Getter
+@Schema(description = "배송지 수정 요청 객체")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class ReqUpdateAddressDtoV1 {
 
+    @Schema(description = "별칭", example = "자취방")
     private String alias;
 
+    @Schema(description = "주소", example = "서울특별시 종로구 사직로161")
     @NotBlank(message = "배송지 주소는 필수 입력 사항입니다.")
     private String address;
 
+    @Schema(description = "상세주소", example = "경복궁")
     private String detail;
 
+    @Schema(description = "우편번호", example = "03045")
     private String zipCode;
 
+    @Schema(description = "기본 배송지 여부", example = "true")
     private Boolean isDefault;
 }

--- a/src/main/java/com/example/whostolemyfood/ai/presentation/controller/AiLogControllerV1.java
+++ b/src/main/java/com/example/whostolemyfood/ai/presentation/controller/AiLogControllerV1.java
@@ -1,4 +1,4 @@
-package com.example.whostolemyfood.ai.presentation.controller;
-
-public class AiLogControllerV1 {
-}
+//package com.example.whostolemyfood.ai.presentation.controller;
+//
+//public class AiLogControllerV1 {
+//}

--- a/src/main/java/com/example/whostolemyfood/area/presentation/controller/AreaControllerV1.java
+++ b/src/main/java/com/example/whostolemyfood/area/presentation/controller/AreaControllerV1.java
@@ -6,6 +6,9 @@ import com.example.whostolemyfood.area.presentation.dto.request.ReqUpdateAreaDto
 import com.example.whostolemyfood.area.presentation.dto.response.ResCreateAreaDtoV1;
 import com.example.whostolemyfood.area.presentation.dto.response.ResGetAreaDtoV1;
 import com.example.whostolemyfood.user.application.security.AuthUser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -18,6 +21,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.UUID;
 
+@Tag(name = "Area API", description = "운영지역 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/areas")
@@ -25,6 +29,7 @@ public class AreaControllerV1 {
 
 	private final AreaServiceV1 areaServiceV1;
 
+	@Operation(summary = "운영지역 생성", description = "[MANAGER / MASTER] 서비스 운영지역을 생성합니다.")
 	@PostMapping
 	@PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
 	public ResponseEntity<ResCreateAreaDtoV1> createArea(
@@ -34,21 +39,25 @@ public class AreaControllerV1 {
 		return ResponseEntity.ok(areaServiceV1.createArea(loginUser, reqDto));
 	}
 
+	@Operation(summary = "모든 운영지역 조회", description = "[ALL] 모든 운영지역을 조회합니다.")
 	@GetMapping
 	public ResponseEntity<List<ResGetAreaDtoV1>> getAllAreas() {
 		return ResponseEntity.ok(areaServiceV1.getAllAreas());
 	}
 
+	@Operation(summary = "활성화된 운영지역 조회", description = "[ALL] 현재 서비스 활성화가 된 지역을 조회합니다.")
 	@GetMapping("/active")
 	public ResponseEntity<List<ResGetAreaDtoV1>> getActiveAreas() {
 		return ResponseEntity.ok(areaServiceV1.getActiveAreas());
 	}
 
+	@Operation(summary = "특정 지역 상세 정보 조회", description = "[ALL] 특정 지역의 정보를 조회합니다.")
 	@GetMapping("/{areaId}")
 	public ResponseEntity<ResGetAreaDtoV1> getArea(@PathVariable UUID areaId) {
 		return ResponseEntity.ok(areaServiceV1.getArea(areaId));
 	}
 
+	@Operation(summary = "지역 조건 검색 및 목록 조회", description = "[ALL] 시(city), 구(district), 활성화 여부를 조건으로 지역을 검색합니다.")
 	@GetMapping("/search")
 	public ResponseEntity<Page<ResGetAreaDtoV1>> searchAreas(
 		@RequestParam(required = false) String city,
@@ -63,6 +72,7 @@ public class AreaControllerV1 {
 		);
 	}
 
+	@Operation(summary = "지역 정보 수정", description = "[MANGER / MASTER] 지역정보를 수정합니다.")
 	@PutMapping("/{areaId}")
 	@PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
 	public ResponseEntity<ResGetAreaDtoV1> updateArea(
@@ -73,6 +83,7 @@ public class AreaControllerV1 {
 		return ResponseEntity.ok(areaServiceV1.updateArea(loginUser, areaId, reqDto));
 	}
 
+	@Operation(summary = "지역 활성화 상태 변경", description = "[MANAGER / MASTER] 특정 지역의 활성화 여부를 변경합니다.")
 	@PatchMapping("/{areaId}/active")
 	@PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
 	public ResponseEntity<ResGetAreaDtoV1> updateAreaActive(
@@ -83,6 +94,7 @@ public class AreaControllerV1 {
 		return ResponseEntity.ok(areaServiceV1.updateAreaActive(loginUser, areaId, isActive));
 	}
 
+	@Operation(summary = "지역 정보 삭제", description = "[MANAGER / MASTER] 지정한 지역 정보를 삭제합니다")
 	@DeleteMapping("/{areaId}")
 	@PreAuthorize("hasAnyRole('MANAGER', 'MASTER')")
 	public ResponseEntity<Void> deleteArea(

--- a/src/main/java/com/example/whostolemyfood/area/presentation/dto/request/ReqCreateAreaDtoV1.java
+++ b/src/main/java/com/example/whostolemyfood/area/presentation/dto/request/ReqCreateAreaDtoV1.java
@@ -1,19 +1,26 @@
 package com.example.whostolemyfood.area.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Schema(description = "운영지역 생성 요청 객체")
 @NoArgsConstructor
 public class ReqCreateAreaDtoV1 {
 
+	@Schema(description = "지역명", example = "광화문")
 	@NotBlank(message = "지역명은 필수입니다.")
 	private String ukName;
 
+	@Schema(description = "시 / 도", example = "서울특별시")
 	@NotBlank(message = "시는 필수입니다.")
 	private String city;
 
+	@Schema(description = "구 / 군", example = "종로구")
 	@NotBlank(message = "구는 필수입니다.")
 	private String district;
 }

--- a/src/main/java/com/example/whostolemyfood/area/presentation/dto/request/ReqUpdateAreaDtoV1.java
+++ b/src/main/java/com/example/whostolemyfood/area/presentation/dto/request/ReqUpdateAreaDtoV1.java
@@ -1,19 +1,25 @@
 package com.example.whostolemyfood.area.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Schema(description = "운영지역 수정 요청 객체")
 @NoArgsConstructor
 public class ReqUpdateAreaDtoV1 {
 
+	@Schema(description = "지역명", example = "경복궁")
 	@NotBlank(message = "지역명은 필수입니다.")
 	private String ukName;
 
+	@Schema(description = "시 / 도", example = "서울특별시")
 	@NotBlank(message = "시는 필수입니다.")
 	private String city;
 
+	@Schema(description = "구 / 군", example = "종로구")
 	@NotBlank(message = "구는 필수입니다.")
 	private String district;
 }

--- a/src/main/java/com/example/whostolemyfood/auth/presentation/controller/AuthControllerV1.java
+++ b/src/main/java/com/example/whostolemyfood/auth/presentation/controller/AuthControllerV1.java
@@ -1,5 +1,7 @@
 package com.example.whostolemyfood.auth.presentation.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
 import org.springframework.http.HttpStatus;
@@ -19,6 +21,7 @@ import com.example.whostolemyfood.user.domain.entity.UserEntity;
 
 import lombok.RequiredArgsConstructor;
 
+@Tag(name = "Auth API", description = "계정 권한 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
@@ -27,18 +30,21 @@ public class AuthControllerV1 {
     private final AuthServiceV1 authServiceV1;
 
     // 회원가입
+    @Operation(summary = "회원가입",description = "계정을 생성하고 시스템 이용 권한을 부여합니다")
     @PostMapping("/signup")
     public ResponseEntity<ResSignUpDtoV1> signUp(@Valid @RequestBody ReqSignUpDtoV1 requestDto) {
         return ResponseEntity.status(HttpStatus.CREATED).body(authServiceV1.signup(requestDto));
     }
 
     // 로그인
+    @Operation(summary = "로그인",description = "Access 토큰을 발급합니다")
     @PostMapping("/login")
     public ResponseEntity<ResLoginDtoV1> login(@Valid @RequestBody ReqLoginDtoV1 requestDto) {
         return ResponseEntity.ok(authServiceV1.login(requestDto));
     }
 
     // 로그아웃
+    @Operation(summary = "로그아웃",description = "로그아웃합니다")
     @PostMapping("/logout")
     public ResponseEntity<String> logout(@AuthenticationPrincipal AuthUser loginUser) { // UserEntity -> AuthUser
         authServiceV1.logout(loginUser.userId());
@@ -46,6 +52,7 @@ public class AuthControllerV1 {
     }
 
     // 회원 탈퇴
+    @Operation(summary = "회원탈퇴",description = "계정을 삭제(isDelete)합니다")
     @PostMapping("/signout")
     public ResponseEntity<String> signout(@AuthenticationPrincipal AuthUser loginUser) { // UserEntity -> AuthUser
         authServiceV1.signout(loginUser.userId());

--- a/src/main/java/com/example/whostolemyfood/auth/presentation/dto/request/ReqLoginDtoV1.java
+++ b/src/main/java/com/example/whostolemyfood/auth/presentation/dto/request/ReqLoginDtoV1.java
@@ -1,17 +1,21 @@
 package com.example.whostolemyfood.auth.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 import lombok.*;
 
 @Getter
+@Schema(description = "사용자 로그인 요청 객체")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class ReqLoginDtoV1 {
 
+    @Schema(description = "이메일", example = "test@email.com")
     @NotBlank(message = "이메일을 입력해주세요.")
     private String email;
 
+    @Schema(description = "비밀번호", example = "1234Asdf!")
     @NotBlank(message = "비밀번호를 입력해주세요.")
     private String password;
 }

--- a/src/main/java/com/example/whostolemyfood/auth/presentation/dto/request/ReqSignUpDtoV1.java
+++ b/src/main/java/com/example/whostolemyfood/auth/presentation/dto/request/ReqSignUpDtoV1.java
@@ -1,5 +1,6 @@
 package com.example.whostolemyfood.auth.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -11,14 +12,17 @@ import lombok.*;
 
 @Getter
 @Builder
+@Schema(description = "사용자 계정 생성 요청 객체")
 @NoArgsConstructor(access = AccessLevel.PRIVATE) // Jackson을 위한 기본 생성자
 @AllArgsConstructor // 전체 생성자
 public class ReqSignUpDtoV1 {
 
+    @Schema(description = "이메일", example = "test@email.com")
     @NotBlank(message = "이메일은 필수 입력값입니다.")
     @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}$", message = "이메일 형식이 올바르지 않습니다.")
     private String email;
 
+    @Schema(description = "비밀번호", example = "1234Asdf!")
     @NotBlank(message = "비밀번호는 필수 입력값입니다.")
     @Pattern(
             regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-={}:\";'<>?,./]).{8,}$",
@@ -26,15 +30,18 @@ public class ReqSignUpDtoV1 {
     )
     private String password;
 
+    @Schema(description = "사용자 이름", example = "오너테스터")
     @NotBlank(message = "이름은 필수 입력값입니다.")
     @Size(min = 4, max = 10, message = "이름은 4자 이상 10자 이하로 입력해주세요.")
     @Pattern(regexp = "^[a-zA-Z가-힣]+$", message = "이름은 한글 또는 영문만 가능합니다.")
     private String userName;
 
+    @Schema(description = "유저 권한", example = "OWNER")
     @NotNull(message = "유저 타입은 필수입니다.")
     private UserRole userRole;
 
     // 관리자 가입을 위한 토큰
+    @Schema(description = "관리자 가입 토큰")
     private String adminToken;
 
 }

--- a/src/main/java/com/example/whostolemyfood/category/presentation/controller/CategoryControllerV1.java
+++ b/src/main/java/com/example/whostolemyfood/category/presentation/controller/CategoryControllerV1.java
@@ -6,8 +6,11 @@ import com.example.whostolemyfood.category.presentation.dto.response.ResGetCateg
 import com.example.whostolemyfood.global.response.PageResponse;
 import com.example.whostolemyfood.user.application.security.AuthUser;
 import com.example.whostolemyfood.global.util.PageUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.converters.models.PageableAsQueryParam;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
@@ -19,13 +22,17 @@ import java.net.URI;
 import java.util.List;
 import java.util.UUID;
 
+@Tag(name = "Category API", description = "가게 카테고리 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/categories")
 public class CategoryControllerV1 {
+
     private final CategoryServiceV1 categoryService;
 
     // 카테고리 목록 조회
+    @Operation(summary = "카테고리 목록 조회", description = "[ALL] 가게 카테고리 목록을 조회합니다.")
+    @PageableAsQueryParam
     @GetMapping()
     public ResponseEntity<PageResponse<ResGetCategoryDtoV1>> getCategories(
             @AuthenticationPrincipal AuthUser loginUser,
@@ -38,6 +45,7 @@ public class CategoryControllerV1 {
     }
 
     // 카테고리 단일 조회
+    @Operation(summary = "특정 카테고리 상세 조회", description = "[ALL] 특정 가게 카테고리를 조회합니다.")
     @GetMapping("/{category_id}")
     public ResponseEntity<ResGetCategoryDtoV1> getCategory(
             @PathVariable("category_id") UUID categoryId,
@@ -47,6 +55,7 @@ public class CategoryControllerV1 {
     }
 
     // 카테고리 추가
+    @Operation(summary = "카테고리 생성", description = "[MANAGER / MASTER] 새로운 가게 카테고리를 생성합니다.")
     @PostMapping()
     @PreAuthorize("hasAnyRole('MANAGER','MASTER')")
     public ResponseEntity<ResGetCategoryDtoV1> createCategory(
@@ -58,6 +67,7 @@ public class CategoryControllerV1 {
     }
 
     // 카테고리 수정
+    @Operation(summary = "카테고리 수정", description = "[MANAGER / MASTER] 특정 카테고리를 수정합니다.")
     @PutMapping("/{category_id}")
     @PreAuthorize("hasAnyRole('MANAGER','MASTER')")
     public ResponseEntity<ResGetCategoryDtoV1> updateCategory(
@@ -69,6 +79,7 @@ public class CategoryControllerV1 {
     }
 
     // 카테고리 삭제
+    @Operation(summary = "카테고리 삭제", description = "[MANAGER / MASTER] 특정 카테고리를 삭제합니다.")
     @DeleteMapping("/{category_id}")
     @PreAuthorize("hasAnyRole('MANAGER','MASTER')")
     public ResponseEntity<Void> deleteCategory(

--- a/src/main/java/com/example/whostolemyfood/category/presentation/dto/request/ReqCategoryDtoV1.java
+++ b/src/main/java/com/example/whostolemyfood/category/presentation/dto/request/ReqCategoryDtoV1.java
@@ -1,14 +1,18 @@
 package com.example.whostolemyfood.category.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Schema(description = "카테고리 요청 객체")
 @NoArgsConstructor
 @AllArgsConstructor
 public class ReqCategoryDtoV1 {
+
+    @Schema(description = "카테고리명", example = "치킨")
     @NotBlank(message = "카테고리명은 필수입니다.")
     private String name;
 }

--- a/src/main/java/com/example/whostolemyfood/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/whostolemyfood/global/config/security/SecurityConfig.java
@@ -31,7 +31,13 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         // 1. 누구나 접근 가능한 경로
-                        .requestMatchers("/api/v1/auth/signup", "/api/v1/auth/login").permitAll()
+                        .requestMatchers(
+                                "/api/v1/auth/signup",
+                                "/api/v1/auth/login",
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html"
+                        ).permitAll()
 
                         // 2. 인증이 반드시 필요한 경로들
                         .requestMatchers("/api/v1/auth/logout").authenticated() // 로그아웃

--- a/src/main/java/com/example/whostolemyfood/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/example/whostolemyfood/global/config/swagger/SwaggerConfig.java
@@ -1,0 +1,29 @@
+package com.example.whostolemyfood.global.config.swagger;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        String jwtSchemeName = "Bearer Token";
+
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+
+        SecurityScheme securityScheme = new SecurityScheme()
+                .name(jwtSchemeName)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT");
+
+        return new OpenAPI()
+                .addSecurityItem(securityRequirement)
+                .components(new Components().addSecuritySchemes(jwtSchemeName, securityScheme));
+    }
+}

--- a/src/main/java/com/example/whostolemyfood/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/whostolemyfood/global/exception/ErrorCode.java
@@ -69,7 +69,7 @@ public enum ErrorCode {
     AREA_NOT_FOUND(HttpStatus.NOT_FOUND, "AR001", "존재하지 않는 지역입니다."),
     AREA_DUPLICATION(HttpStatus.BAD_REQUEST, "AR002", "이미 존재하는 지역명입니다."),
     AREA_ACCESS_DENIED(HttpStatus.FORBIDDEN, "AR003", "지역 관리 권한이 없습니다."),
-    AREA_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "AR004", "활성화된 지역이 아닙니다");
+    AREA_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "AR004", "활성화된 지역이 아닙니다"),
 
     // Review
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "리뷰를 찾을 수 없습니다."),

--- a/src/main/java/com/example/whostolemyfood/menu/application/service/MenuServiceV1.java
+++ b/src/main/java/com/example/whostolemyfood/menu/application/service/MenuServiceV1.java
@@ -92,13 +92,18 @@ public class MenuServiceV1 {
                 .orElseThrow(()-> new CustomException(ErrorCode.MENU_NOT_FOUND));
         // 유저 권한 확인
         validateMenuAccess(store, authUser);
+
         // 이름이 변경될때만 체크
         if(!menu.getName().equals(request.getName())) {
             if (menuRepository.existsByStore_StoreIdAndNameAndIsDeletedFalse(storeId, request.getName())) {
                 throw new CustomException(ErrorCode.MENU_DUPLICATION_NAME);
             }
         }
-        menu.updateMenu(request);
+
+        // 설명 변경 처리
+        ResGetAiLogDtoV1 aiResult = resolveDescription(request, authUser);
+
+        menu.updateMenu(request, aiResult);
 
         return ResGetMenuDtoV1.from(menu);
     }
@@ -142,9 +147,17 @@ public class MenuServiceV1 {
 
     // description 예외처리
     private ResGetAiLogDtoV1 resolveDescription(ReqCreateMenuDtoV1 request, AuthUser authUser) {
-        boolean useAi = Boolean.TRUE.equals(request.getAiDescription());
-        boolean hasDescription = hasText(request.getDescription());
-        boolean hasAiPrompt = hasText(request.getAiPrompt());
+        return resolveDescriptionLogic(request.getDescription(),request.getAiDescription(), request.getAiPrompt(), authUser);
+    }
+
+    private ResGetAiLogDtoV1 resolveDescription(ReqUpdateMenuDtoV1 request, AuthUser authUser) {
+        return resolveDescriptionLogic(request.getDescription(),request.getAiDescription(),request.getAiPrompt(), authUser);
+    }
+
+    private ResGetAiLogDtoV1 resolveDescriptionLogic(String description, Boolean aiDescription, String aiPrompt, AuthUser authUser) {
+        boolean useAi = Boolean.TRUE.equals(aiDescription);
+        boolean hasDescription = hasText(description);
+        boolean hasAiPrompt = hasText(aiPrompt);
 
         // 1. 설명 없음 +  AI false + 프롬프트 없음 >> null
         if (!hasDescription && !useAi && !hasAiPrompt) {
@@ -163,11 +176,11 @@ public class MenuServiceV1 {
 
         // 4. AI true 면 AI서비스로 이동하여 prompt 검증후 description 생성
         if (useAi) {
-            return aiLogServiceV1.generateMenuDescription(authUser.userId(), request.getAiPrompt());
+            return aiLogServiceV1.generateMenuDescription(authUser.userId(), aiPrompt);
         }
 
         // 5. AI false + 설명만 있으면 설명 저장
-        return new ResGetAiLogDtoV1(request.getDescription(),null);
+        return new ResGetAiLogDtoV1(description,null);
     }
 
     private boolean hasText(String value) {

--- a/src/main/java/com/example/whostolemyfood/menu/domain/entity/MenuEntity.java
+++ b/src/main/java/com/example/whostolemyfood/menu/domain/entity/MenuEntity.java
@@ -1,5 +1,6 @@
 package com.example.whostolemyfood.menu.domain.entity;
 
+import com.example.whostolemyfood.ai.presentation.dto.response.ResGetAiLogDtoV1;
 import com.example.whostolemyfood.global.entity.BaseSoftDeleteEntity;
 import com.example.whostolemyfood.menu.presentation.dto.request.ReqUpdateMenuDtoV1;
 import com.example.whostolemyfood.store.domain.entity.StoreEntity;
@@ -45,10 +46,11 @@ public class MenuEntity extends BaseSoftDeleteEntity {
     @Builder.Default
     private Boolean isDeleted = false;
 
-    public void updateMenu(ReqUpdateMenuDtoV1 request) {
+    public void updateMenu(ReqUpdateMenuDtoV1 request, ResGetAiLogDtoV1 aiResult) {
         this.name = request.getName();
         this.price = request.getPrice();
-        this.description = request.getDescription();
+        this.description = aiResult.description();
+        this.aiLogId = aiResult.aiLogId();
     }
 
     public void deleteMenu(UUID deletedBy) {

--- a/src/main/java/com/example/whostolemyfood/menu/presentation/controller/MenuControllerV1.java
+++ b/src/main/java/com/example/whostolemyfood/menu/presentation/controller/MenuControllerV1.java
@@ -9,8 +9,10 @@ import com.example.whostolemyfood.menu.presentation.dto.response.ResCreateMenuDt
 import com.example.whostolemyfood.menu.presentation.dto.response.ResGetMenuDtoV1;
 import com.example.whostolemyfood.user.application.security.AuthUser;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.converters.models.PageableAsQueryParam;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -23,15 +25,15 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
-
+@Tag(name = "Menu API", description = "메뉴 관리 API")
 @RestController
-@RequestMapping("/api/stores/{storeId}/menus")
+@RequestMapping("/api/v1/stores/{storeId}/menus")
 @RequiredArgsConstructor
 public class MenuControllerV1 {
 
     private final MenuServiceV1 menuServiceV1;
 
-    @Operation(summary = "메뉴 생성", description = "Owner only")
+    @Operation(summary = "메뉴 추가", description = "[OWNER] 메뉴를 추가합니다.")
     @PostMapping
     @PreAuthorize("hasAnyRole('OWNER')")
     public ResponseEntity<ResCreateMenuDtoV1> addMenu(
@@ -43,7 +45,7 @@ public class MenuControllerV1 {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @Operation(summary = "메뉴 조회", description = "All")
+    @Operation(summary = "메뉴 조회", description = "[ALL] 특정 매뉴를 조회합니다.")
     @GetMapping("/{menuId}")
     public ResponseEntity<ResGetMenuDtoV1> getMenu(
             @Valid
@@ -53,7 +55,8 @@ public class MenuControllerV1 {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    @Operation(summary = "메뉴 목록 조회", description = "All")
+    @Operation(summary = "메뉴 목록 조회", description = "[ALL] 메뉴 목록을 조회합니다.")
+    @PageableAsQueryParam
     @GetMapping
     public ResponseEntity<PageResponse<ResGetMenuDtoV1>> getMenus(
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
@@ -63,7 +66,7 @@ public class MenuControllerV1 {
         return ResponseEntity.status(HttpStatus.OK).body(new PageResponse<>(menus));
     }
 
-    @Operation(summary = "메뉴 수정", description = "Owner, Manager, Master")
+    @Operation(summary = "메뉴 수정", description = "[OWNER / MANAGER / MASTER] 특정 메뉴를 수정합니다.")
     @PutMapping("/{menuId}")
     @PreAuthorize("hasAnyRole('OWNER','MANAGER','MASTER')")
     public ResponseEntity<ResGetMenuDtoV1> updateMenu(
@@ -76,7 +79,7 @@ public class MenuControllerV1 {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    @Operation(summary = "메뉴 숨김 / 해제", description = "Owner, Manager, Master")
+    @Operation(summary = "메뉴 숨김 / 해제", description = "[OWNER / MANAGER / MASTER] 특정 메뉴를 숨기거나 노출시킵니다.")
     @PatchMapping("/{menuId}/hide")
     @PreAuthorize("hasAnyRole('OWNER','MANAGER','MASTER')")
     public ResponseEntity<Void> hideMenu(
@@ -88,7 +91,7 @@ public class MenuControllerV1 {
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
-    @Operation(summary = "메뉴 삭제", description = "Owner, Manager, Master")
+    @Operation(summary = "메뉴 삭제", description = "[OWNER / MANAGER / MASTER] 특정 메뉴를 삭제합니다.")
     @DeleteMapping("/{menuId}")
     @PreAuthorize("hasAnyRole('OWNER','MANAGER','MASTER')")
     public void deleteMenu(

--- a/src/main/java/com/example/whostolemyfood/menu/presentation/dto/request/ReqCreateMenuDtoV1.java
+++ b/src/main/java/com/example/whostolemyfood/menu/presentation/dto/request/ReqCreateMenuDtoV1.java
@@ -1,20 +1,28 @@
 package com.example.whostolemyfood.menu.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Schema(description = "메뉴 추가 요청 객체")
 @NoArgsConstructor
 public class ReqCreateMenuDtoV1 {
 
+    @Schema(description = "메뉴명", example = "황금올리브 치킨")
     @NotBlank(message = "메뉴 이름은 필수입니다")
     private String name;
+
+    @Schema(description = "메뉴 가격", example = "23000")
     @Min(value = 0, message = "메뉴 최소 선정금액은 0원 이상이여야 합니다")
     private Integer price;
 
+    @Schema(description = "메뉴 설명(직접작성)", example = "올리브유에 튀긴 치킨")
     private String description;
+    @Schema(description = "AI 추천 설명 사용 여부", example = "false")
     private Boolean aiDescription;
+    @Schema(description = "AI 추천 설명용 프롬포트")
     private String aiPrompt;
 }

--- a/src/main/java/com/example/whostolemyfood/menu/presentation/dto/request/ReqUpdateMenuDtoV1.java
+++ b/src/main/java/com/example/whostolemyfood/menu/presentation/dto/request/ReqUpdateMenuDtoV1.java
@@ -1,15 +1,26 @@
 package com.example.whostolemyfood.menu.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
+@Schema(description = "메뉴 수정 요청 객체")
 public class ReqUpdateMenuDtoV1 {
 
-    @NotBlank(message = "메뉴 이름은 필수입니다")
+    @Schema(description = "메뉴 명", example = "황금올리브치킨")
+    @NotBlank(message = "메뉴 명은 필수입니다")
     private String name;
+
+    @Schema(description = "메뉴 가격", example = "25000")
     @Min(value = 0, message = "메뉴 최소 선정 금액은 0원 이상이여야합니다")
     private Integer price;
+
+    @Schema(description = "메뉴 설명(직접입력)", example = "올리브유에 튀긴 치킨")
     private String description;
+    @Schema(description = "AI 추천 설명 사용 여부",example = "false")
+    private Boolean aiDescription;
+    @Schema(description = "AI 추천 설명용 프롬프트",example = "")
+    private String aiPrompt;
 }

--- a/src/main/java/com/example/whostolemyfood/order/presentation/controller/OrderControllerV1.java
+++ b/src/main/java/com/example/whostolemyfood/order/presentation/controller/OrderControllerV1.java
@@ -38,7 +38,7 @@ public class OrderControllerV1 {
     /**
      * 주문 생성 API (CUSTOMER 전용)
      */
-    @Operation(summary = "주문 생성", description = "새로운 주문을 생성합니다. (CUSTOMER 전용)")
+    @Operation(summary = "주문 생성", description = "[CUSTOMER] 새로운 주문을 생성합니다.")
     @PostMapping
     @PreAuthorize("hasAnyRole('CUSTOMER')")
     public ResponseEntity<ResCreateOrderDtoV1> createOrder(
@@ -50,7 +50,7 @@ public class OrderControllerV1 {
     /**
      * 주문 상세 조회 API
      */
-    @Operation(summary = "주문 상세 조회", description = "본인의 주문 또는 내 가게 주문, 관리자 권한으로 조회합니다.")
+    @Operation(summary = "주문 상세 조회", description = "[ALL] 본인의 주문 또는 내 가게 주문, 관리자 권한으로 조회합니다.")
     @GetMapping("/{orderId}")
     @PreAuthorize("hasAnyRole('CUSTOMER', 'OWNER', 'MANAGER', 'MASTER')")
     public ResponseEntity<ResGetOrderDtoV1> getOrder(
@@ -62,7 +62,7 @@ public class OrderControllerV1 {
     /**
      * 주문 목록 조회 및 검색 API
      */
-    @Operation(summary = "주문 목록 조회 및 검색", description = "권한에 따라 접근 가능한 주문 목록을 필터링하여 조회합니다.")
+    @Operation(summary = "주문 목록 조회 및 검색", description = "[ALL] 권한에 따라 접근 가능한 주문 목록을 필터링하여 조회합니다.")
     @GetMapping
     @PreAuthorize("hasAnyRole('CUSTOMER', 'OWNER', 'MANAGER', 'MASTER')")
     public ResponseEntity<PageResponse<ResGetOrderListDtoV1>> getOrders(
@@ -80,7 +80,7 @@ public class OrderControllerV1 {
     /**
      * 주문 요청사항 수정 API (CUSTOMER 전용)
      */
-    @Operation(summary = "주문 요청사항 수정", description = "본인의 주문 중 수락 전(PENDING) 상태에서만 수정 가능합니다.")
+    @Operation(summary = "주문 요청사항 수정", description = "[CUSTOMER] 본인의 주문 중 수락 전(PENDING) 상태에서만 수정 가능합니다.")
     @PutMapping("/{orderId}")
     @PreAuthorize("hasAnyRole('CUSTOMER')")
     public ResponseEntity<ResGetOrderDtoV1> updateOrderRequest(
@@ -93,7 +93,7 @@ public class OrderControllerV1 {
     /**
      * 주문 취소 API (CUSTOMER, MASTER 전용)
      */
-    @Operation(summary = "주문 취소", description = "본인의 주문(5분 이내) 또는 MASTER 권한으로 취소 가능합니다.")
+    @Operation(summary = "주문 취소", description = "[CUSTOMER / MASTER] 본인의 주문(5분 이내) 또는 MASTER 권한으로 취소 가능합니다.")
     @PatchMapping("/{orderId}/cancel")
     @PreAuthorize("hasAnyRole('CUSTOMER', 'MASTER')")
     public ResponseEntity<ResGetOrderDtoV1> cancelOrder(
@@ -105,7 +105,7 @@ public class OrderControllerV1 {
     /**
      * 주문 상태 변경 API (OWNER, MANAGER, MASTER 전용)
      */
-    @Operation(summary = "주문 상태 변경", description = "가게 사장님(내 가게 한정) 또는 관리자만 상태를 단계별로 변경할 수 있습니다.")
+    @Operation(summary = "주문 상태 변경", description = "[OWNER / MANAGER / MASTER] 가게 사장님(내 가게 한정) 또는 관리자만 상태를 단계별로 변경할 수 있습니다.")
     @PatchMapping("/{orderId}/status")
     @PreAuthorize("hasAnyRole('OWNER', 'MANAGER', 'MASTER')")
     public ResponseEntity<ResGetOrderDtoV1> updateOrderStatus(
@@ -118,7 +118,7 @@ public class OrderControllerV1 {
     /**
      * 주문 삭제 API (MASTER 전용 🚨)
      */
-    @Operation(summary = "주문 삭제", description = "오직 MASTER 권한으로만 주문 내역을 Soft Delete 처리합니다.")
+    @Operation(summary = "주문 삭제", description = "[MASTER] MASTER 권한으로만 주문 내역을 Soft Delete 처리합니다.")
     @DeleteMapping("/{orderId}")
     @PreAuthorize("hasAnyRole('MASTER')")
     public ResponseEntity<Void> deleteOrder(

--- a/src/main/java/com/example/whostolemyfood/order/presentation/dto/request/ReqCancelOrderDtoV1.java
+++ b/src/main/java/com/example/whostolemyfood/order/presentation/dto/request/ReqCancelOrderDtoV1.java
@@ -1,11 +1,15 @@
 package com.example.whostolemyfood.order.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 @Getter
+@Schema(description = "주문 취소 요청 객체")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class ReqCancelOrderDtoV1 {
+
+    @Schema(description = "취소 사유", example = "다른 음식이 먹고 싶어졌어요.")
     private String cancelReason;
 }

--- a/src/main/java/com/example/whostolemyfood/order/presentation/dto/request/ReqCreateOrderDtoV1.java
+++ b/src/main/java/com/example/whostolemyfood/order/presentation/dto/request/ReqCreateOrderDtoV1.java
@@ -1,5 +1,6 @@
 package com.example.whostolemyfood.order.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
@@ -9,19 +10,24 @@ import java.util.List;
 import java.util.UUID;
 
 @Getter
+@Schema(description = "주문 생성 요청 객체")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class ReqCreateOrderDtoV1 {
 
+    @Schema(description = "가게 정보", example = "")
     @NotNull(message = "가게 정보는 필수입니다.")
     private UUID storeId;
 
+    @Schema(description = "배송지 정보", example = "")
     @NotNull(message = "배송지 정보는 필수입니다.")
     private UUID addressId;
 
+    @Schema(description = "요청사항", example = "문앞에 두고 가주세요.")
     private String request;
 
+    @Schema(description = "주문 상품")
     @Valid // List 내부의 OrderItemRequest 객체들까지 유효성 검사 수행
     @NotEmpty(message = "주문 상품은 최소 하나 이상이어야 합니다.")
     private List<OrderItemRequest> orderItems;
@@ -31,13 +37,16 @@ public class ReqCreateOrderDtoV1 {
     @AllArgsConstructor
     @Builder
     public static class OrderItemRequest {
+        @Schema(description = "메뉴 정보")
         @NotNull(message = "메뉴 정보는 필수입니다.")
         private UUID menuId;
 
+        @Schema(description = "메뉴 수량")
         @NotNull(message = "수량은 필수입니다.")
         @Min(value = 1, message = "수량은 최소 1개 이상이어야 합니다.")
         private Integer quantity;
 
+        @Schema(description = "총 주문액")
         @NotNull(message = "가격 정보는 필수입니다.")
         private Integer priceAtOrder;
     }

--- a/src/main/java/com/example/whostolemyfood/order/presentation/dto/request/ReqUpdateOrderRequestDtoV1.java
+++ b/src/main/java/com/example/whostolemyfood/order/presentation/dto/request/ReqUpdateOrderRequestDtoV1.java
@@ -1,13 +1,17 @@
 package com.example.whostolemyfood.order.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
 @Getter
+@Schema(description = "주문 수정 요청 객체")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class ReqUpdateOrderRequestDtoV1 {
+
+    @Schema(description = "요청사항", example = "벨 누르지 말아주세요.")
     @NotBlank(message = "요청사항 내용은 비어있을 수 없습니다.")
     private String request;
 }

--- a/src/main/java/com/example/whostolemyfood/order/presentation/dto/request/ReqUpdateOrderStatusDtoV1.java
+++ b/src/main/java/com/example/whostolemyfood/order/presentation/dto/request/ReqUpdateOrderStatusDtoV1.java
@@ -1,14 +1,18 @@
 package com.example.whostolemyfood.order.presentation.dto.request;
 
 import com.example.whostolemyfood.order.domain.entity.OrderStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 @Getter
+@Schema(description = "주문 상태 변경 요청 객체")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class ReqUpdateOrderStatusDtoV1 {
+
+    @Schema(description = "주문 상태")
     @NotNull(message = "변경할 상태 정보는 필수입니다.")
     private OrderStatus status;
 }

--- a/src/main/java/com/example/whostolemyfood/payment/presentation/controller/PaymentControllerV1.java
+++ b/src/main/java/com/example/whostolemyfood/payment/presentation/controller/PaymentControllerV1.java
@@ -8,6 +8,8 @@ import com.example.whostolemyfood.payment.presentation.dto.request.ReqMakePay;
 import com.example.whostolemyfood.payment.presentation.dto.request.ReqModifyPay;
 import com.example.whostolemyfood.payment.presentation.dto.response.*;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -19,6 +21,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.Map;
 import java.util.UUID;
 
+@Tag(name = "Payment API", description = "결제 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/pay")
@@ -27,34 +30,35 @@ public class PaymentControllerV1 {
     private final PaymentServiceV1 paymentService;
     private final PaymentServiceExtend paymentServiceExtend;
 
-    @Operation(description = "결제 목록 조회")
+    @Operation(summary = "결제 목록 조회", description = "결제 목록 조회")
     @GetMapping("/list")
     ResponseEntity<?> getPayments(@PageableDefault(page = 0, size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         PageRes<ResPayList> payments = paymentService.getPayments(pageable);
         return ResponseEntity.ok().body(ResDto.success(payments));
     }
 
-    @Operation(description = "결제 단일 상세  조회")
+    @Operation(summary = "결제 단일 생세 조회", description = "결제 단일 상세  조회")
     @GetMapping("/{id}")
     ResponseEntity<?> getPaymentById(@PathVariable("id") UUID id) {
         ResGetPayById paymentById = paymentService.getPaymentById(id);
         return ResponseEntity.ok().body(ResDto.success(paymentById));
     }
 
-    @Operation(description = "결제 요청")
+    @Operation(summary = "결제 요청", description = "결제 요청")
     @PostMapping
     ResponseEntity<?> postPayment(@Valid @RequestBody ReqMakePay reqMakePay) {
         ResMakePay resMakePay = paymentService.postPayment(reqMakePay);
         return ResponseEntity.ok().body(ResDto.success(resMakePay));
     }
 
-    @Operation(description = "결제 상태 변경(취소)")
+    @Operation(summary = "결제 상태 변경(취소)", description = "결제 상태 변경(취소)")
     @PatchMapping("/modify")
     ResponseEntity<?> updatePayment(@Valid @RequestBody ReqModifyPay reqModifyPay) {
         ResModifyPay resModifyPay = paymentService.updatePayment(reqModifyPay);
         return ResponseEntity.ok().body(ResDto.success(resModifyPay));
     }
 
+    @Operation(summary = "결제 확인")
     @PostMapping("/confirm")
     ResponseEntity<?> confirm(@RequestBody ReqConfirmDto reqConfirmDto) {
         paymentServiceExtend.payProcess(reqConfirmDto);

--- a/src/main/java/com/example/whostolemyfood/review/presentation/controller/ReviewControllerV1.java
+++ b/src/main/java/com/example/whostolemyfood/review/presentation/controller/ReviewControllerV1.java
@@ -11,6 +11,8 @@ import com.example.whostolemyfood.review.presentation.dto.response.ResGetReviewD
 import com.example.whostolemyfood.review.presentation.dto.response.ResGetReviewPageDtoV1;
 import com.example.whostolemyfood.review.presentation.dto.response.ResGetStoreRatingSummaryDtoV1;
 import com.example.whostolemyfood.user.application.security.AuthUser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
+@Tag(name = "Review API", description = "리뷰 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
@@ -28,6 +31,7 @@ public class ReviewControllerV1 {
 	private final ReviewServiceV1 reviewServiceV1;
 	private final ReviewRatingBatchService reviewRatingBatchService;
 
+	@Operation(summary = "리뷰 작성", description = "[CUSTOMER] 리뷰를 작성합니다.")
 	@PostMapping("/orders/{orderId}/reviews")
 	@PreAuthorize("hasRole('CUSTOMER')")
 	public ResponseEntity<ResCreateReviewDtoV1> createReview(
@@ -44,6 +48,7 @@ public class ReviewControllerV1 {
 		return ResponseEntity.ok(response);
 	}
 
+	@Operation(summary = "특정 리뷰 상세 조회", description = "[ALL] 특정 리뷰를 조회합니다.")
 	@GetMapping("/reviews/{reviewId}")
 	public ResponseEntity<ResGetReviewDtoV1> getReview(
 		@PathVariable UUID reviewId
@@ -52,6 +57,7 @@ public class ReviewControllerV1 {
 		return ResponseEntity.ok(response);
 	}
 
+	@Operation(summary = "특정 리뷰 수정", description = "[CUSTOMER] 작성한 특정 리뷰를 수정합니다.")
 	@PutMapping("/reviews/{reviewId}")
 	@PreAuthorize("hasRole('CUSTOMER')")
 	public ResponseEntity<ResGetReviewDtoV1> updateReview(
@@ -68,6 +74,7 @@ public class ReviewControllerV1 {
 		return ResponseEntity.ok(response);
 	}
 
+	@Operation(summary = "리뷰 삭제", description = "[CUSTOMER / MANAGER / MASTER] 특정 리뷰를 삭제합니다.")
 	@DeleteMapping("/reviews/{reviewId}")
 	@PreAuthorize("hasAnyRole('CUSTOMER','MANAGER','MASTER')")
 	public ResponseEntity<String> deleteReview(
@@ -82,6 +89,7 @@ public class ReviewControllerV1 {
 		return ResponseEntity.ok("리뷰 삭제가 완료되었습니다.");
 	}
 
+	@Operation(summary = "평점 조회", description = "가게 리뷰 평점을 조회 합니다.")
 	@GetMapping("/stores/{storeId}/rating-summary")
 	public ResponseEntity<ResGetStoreRatingSummaryDtoV1> getStoreRatingSummary(
 		@PathVariable UUID storeId
@@ -90,6 +98,7 @@ public class ReviewControllerV1 {
 		return ResponseEntity.ok(response);
 	}
 
+	@Operation(summary = "리뷰 목록 조회", description = "리뷰 목록을 조회합니다.")
 	@GetMapping("/reviews")
 	public ResponseEntity<PageResponse<ResGetReviewPageDtoV1>> getReviews(
 		@ModelAttribute ReqGetReviewsDtoV1 request
@@ -100,6 +109,7 @@ public class ReviewControllerV1 {
 		return ResponseEntity.ok(response);
 	}
 
+	@Operation(summary = "가게 평점 집계", description = "[MANAGER / MASTER] 가게 평점을 집계합니다.")
 	@PostMapping("/reviews/rating-summary/refresh")
 	@PreAuthorize("hasAnyRole('MANAGER','MASTER')")
 	public ResponseEntity<String> refreshRatingSummary() {

--- a/src/main/java/com/example/whostolemyfood/review/presentation/dto/request/ReqCreateReviewDtoV1.java
+++ b/src/main/java/com/example/whostolemyfood/review/presentation/dto/request/ReqCreateReviewDtoV1.java
@@ -1,5 +1,6 @@
 package com.example.whostolemyfood.review.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -7,12 +8,15 @@ import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
+@Schema(description = "리뷰 생성 요청 객체")
 public class ReqCreateReviewDtoV1 {
 
+	@Schema(description = "평점", example = "5")
 	@Min(value = 1, message = "평점은 1점 이상이어야 합니다.")
 	@Max(value = 5, message = "평점은 5점 이하여야 합니다.")
 	private Integer rating;
 
+	@Schema(description = "리뷰 내용", example = "음식이 맛있네요.")
 	@NotBlank(message = "리뷰 내용은 비어 있을 수 없습니다.")
 	@Size(max = 1000, message = "리뷰 내용은 1000자 이하여야 합니다.")
 	private String content;

--- a/src/main/java/com/example/whostolemyfood/review/presentation/dto/request/ReqGetReviewsDtoV1.java
+++ b/src/main/java/com/example/whostolemyfood/review/presentation/dto/request/ReqGetReviewsDtoV1.java
@@ -1,5 +1,6 @@
 package com.example.whostolemyfood.review.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.Getter;
@@ -12,10 +13,10 @@ import java.util.UUID;
 
 @Getter
 @Setter
+@Schema(description = "리뷰 조회 요청 객체")
 public class ReqGetReviewsDtoV1 {
 
 	private UUID storeId;
-
 	@Min(value = 1, message = "평점은 1 이상이어야 합니다.")
 	@Max(value = 5, message = "평점은 5 이하여야 합니다.")
 	private Integer rating;

--- a/src/main/java/com/example/whostolemyfood/review/presentation/dto/request/ReqUpdateReviewDtoV1.java
+++ b/src/main/java/com/example/whostolemyfood/review/presentation/dto/request/ReqUpdateReviewDtoV1.java
@@ -1,5 +1,6 @@
 package com.example.whostolemyfood.review.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -7,12 +8,15 @@ import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
+@Schema(description = "리뷰수정 요청 객체")
 public class ReqUpdateReviewDtoV1 {
 
+	@Schema(description = "평점", example = "5")
 	@Min(value = 1, message = "평점은 1점 이상이어야 합니다.")
 	@Max(value = 5, message = "평점은 5점 이하여야 합니다.")
 	private Integer rating;
 
+	@Schema(description = "리뷰 내용", example = "맛있습니다.")
 	@NotBlank(message = "리뷰 내용은 비어 있을 수 없습니다.")
 	@Size(max = 1000, message = "리뷰 내용은 1000자 이하여야 합니다.")
 	private String content;

--- a/src/main/java/com/example/whostolemyfood/store/domain/entity/StoreRatingSummaryEntity.java
+++ b/src/main/java/com/example/whostolemyfood/store/domain/entity/StoreRatingSummaryEntity.java
@@ -85,18 +85,4 @@ public class StoreRatingSummaryEntity extends BaseSoftDeleteEntity {
 		this.rating4Count = rating4Count;
 		this.rating5Count = rating5Count;
 	}
-
-	public static StoreRatingSummaryEntity createDefault() {
-		return StoreRatingSummaryEntity.builder()
-				.reviewCount(0)
-				.totalRatingSum(0)
-				.averageRating(BigDecimal.ZERO.setScale(1, RoundingMode.HALF_UP))
-				.rating1Count(0)
-				.rating2Count(0)
-				.rating3Count(0)
-				.rating4Count(0)
-				.rating5Count(0)
-				.isDeleted(false)
-				.build();
-	}
 }

--- a/src/main/java/com/example/whostolemyfood/store/presentation/controller/StoreControllerV1.java
+++ b/src/main/java/com/example/whostolemyfood/store/presentation/controller/StoreControllerV1.java
@@ -13,8 +13,10 @@ import com.example.whostolemyfood.store.presentation.dto.response.ResGetStoreLis
 import com.example.whostolemyfood.user.application.security.AuthUser;
 import com.example.whostolemyfood.store.presentation.dto.response.StoreSearchResponseDtoV1;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.converters.models.PageableAsQueryParam;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -27,8 +29,9 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
+@Tag(name = "Store API", description = "가게 관리 API")
 @RestController
-@RequestMapping("/api/stores")
+@RequestMapping("/api/v1/stores")
 @RequiredArgsConstructor
 public class StoreControllerV1 {
 
@@ -36,7 +39,7 @@ public class StoreControllerV1 {
     private final StoreSearchServiceV1 storeSearchService;
 
     // Owner Only
-    @Operation(summary = "스토어 생성", description = "Owner Only")
+    @Operation(summary = "가게 생성", description = "[OWNER] 가게를 등록합니다.")
     @PostMapping
     @PreAuthorize("hasAnyRole('OWNER')")
     public ResponseEntity<ResCreateStoreDtoV1> createStore(
@@ -48,14 +51,15 @@ public class StoreControllerV1 {
     }
 
     // ALL
-    @Operation(summary = "스토어 조회", description = "All")
+    @Operation(summary = "가게 조회", description = "[ALL] 특정 가게를 조회합니다.")
     @GetMapping("/{storeId}")
     public ResponseEntity<ResGetStoreDtoV1> getStore(@PathVariable UUID storeId) {
         ResGetStoreDtoV1 response = storeServiceV1.getStore(storeId);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    @Operation(summary = "스토어 목록조회", description = "All")
+    @Operation(summary = "가게 목록조회", description = "[ALL] 모든 가게 목록을 조회합니다.")
+    @PageableAsQueryParam
     @GetMapping
     public ResponseEntity<PageResponse<ResGetStoreListDtoV1>> getStores(
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC)Pageable pageable) {
@@ -67,7 +71,7 @@ public class StoreControllerV1 {
     }
 
     // Owner, manager, master
-    @Operation(summary = "스토어 수정", description = "Owner, Manager, Master")
+    @Operation(summary = "가게 수정", description = "[OWNER / MANAGER / MASTER] 가게의 정보를 수정합니다.")
     @PutMapping("/{storeId}")
     @PreAuthorize("hasAnyRole('OWNER','MANAGER','MASTER')")
     public ResponseEntity<ResGetStoreDtoV1> updateStore(
@@ -79,7 +83,7 @@ public class StoreControllerV1 {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    @Operation(summary = "스토어 숨김 / 노출", description = "Owner, Manager, Master")
+    @Operation(summary = "가게 숨김 / 노출", description = "[OWNER / MANAGER / MASTER] 가게를 숨기거나 노출시킬 수 있습니다.")
     @PatchMapping("/{storeId}/hide")
     @PreAuthorize("hasAnyRole('OWNER','MANAGER','MASTER')")
     public ResponseEntity<Void> hideStore(
@@ -90,7 +94,7 @@ public class StoreControllerV1 {
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
-    @Operation(summary = "스토어 삭제", description = "Owner, Manager, Master")
+    @Operation(summary = "가게 삭제", description = "[OWNER / MANAGER / MASTER]] 가게를 삭제시킵니다.")
     @DeleteMapping("/{storeId}")
     @PreAuthorize("hasAnyRole('OWNER','MANAGER','MASTER')")
     public void deleteStore(
@@ -100,7 +104,8 @@ public class StoreControllerV1 {
         storeServiceV1.deleteStore(storeId, authUser);
     }
 
-    @Operation(summary = "조건별 조회", description = "가계명,카테고라,지역명으로 조회 가능")
+    @Operation(summary = "조건별 조회", description = "[ALL] 가게명,카테고리,지역명으로 가게를 조회합니다.")
+    @PageableAsQueryParam
     @GetMapping("/search")
     public ResponseEntity<PageResponse<StoreSearchResponseDtoV1>> search(
             @ModelAttribute StoreSearchConditionV1 condition,

--- a/src/main/java/com/example/whostolemyfood/store/presentation/dto/request/ReqCreateStoreDtoV1.java
+++ b/src/main/java/com/example/whostolemyfood/store/presentation/dto/request/ReqCreateStoreDtoV1.java
@@ -1,6 +1,7 @@
 package com.example.whostolemyfood.store.presentation.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -12,31 +13,41 @@ import java.time.LocalTime;
 import java.util.UUID;
 
 @Getter
+@Schema(description = "가게 생성 요청 객체")
 @NoArgsConstructor
 public class ReqCreateStoreDtoV1 {
 
+    @Schema(description = "가게명", example = "광화문 오다리 치킨")
     @NotBlank(message = "가게 이름은 필수입니다")
     private String name;
 
+    @Schema(description = "가게 주소", example = "서울특별시 종로구 사직로 10")
     @NotBlank(message = "가게 주소는 필수입니다")
     private String address;
 
+    @Schema(description = "가게 번호", example = "000-0000-0000")
     @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "올바른 전화번호 형식이 아닙니다.")
     private String phone;
 
+    @Schema(description = "가게 정보", example = "광화문 최고 맛집 치킨집")
     private String content;
 
+    @Schema(description = "카테고리")
     private UUID categoryId;
 
+    @Schema(description = "운영지역")
     private UUID areaId;
 
+    @Schema(description = "가게 최소 주문 금액", example = "20000")
     @Min(value = 0, message = "최소 주문 금액은 0원 이상이어야 합니다")
     private Integer minOrderPrice;
 
+    @Schema(description = "영업 시작 시간", example = "10:00")
     @NotNull(message = "영업 시작시간은 필수입니다")
     @JsonFormat(pattern = "HH:mm")
     private LocalTime openTime;
 
+    @Schema(description = "영업 종료 시간", example = "23:00")
     @NotNull(message = "영업 종료시간은 필수입니다")
     @JsonFormat(pattern = "HH:mm")
     private LocalTime closeTime;

--- a/src/main/java/com/example/whostolemyfood/store/presentation/dto/request/ReqUpdateStoreDtoV1.java
+++ b/src/main/java/com/example/whostolemyfood/store/presentation/dto/request/ReqUpdateStoreDtoV1.java
@@ -2,6 +2,7 @@ package com.example.whostolemyfood.store.presentation.dto.request;
 
 import com.example.whostolemyfood.store.domain.entity.StoreStatus;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -12,35 +13,44 @@ import java.time.LocalTime;
 import java.util.UUID;
 
 @Getter
+@Schema(description = "가게 수정 요청 객체")
 public class ReqUpdateStoreDtoV1 {
 
+    @Schema(description = "가게명", example = "광화문 오대리 치킨")
     @NotBlank(message = "가게 이름은 필수입니다")
     private String name;
 
+    @Schema(description = "가게주소", example = "서울특별시 종로구 사직로77")
     @NotBlank(message = "가게 주소는 필수입니다")
     private String address;
 
+    @Schema(description = "가게번호", example = "000-0000-0000")
     @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "올바른 전화번호 형식이 아닙니다.")
     private String phone;
 
+    @Schema(description = "가게정보", example = "광화문 최고 맛집 치킨집")
     private String content;
 
+    @Schema(description = "카테고리")
     private UUID categoryId;
 
+    @Schema(description = "운영지역")
     private UUID areaId;
 
+    @Schema(description = "최소 주문 금액", example = "20000")
     @Min(value = 0, message = "최소 주문 금액은 0원 이상이어야 합니다")
     private Integer minOrderPrice;
 
+    @Schema(description = "영업 시작 시간", example = "10:00")
     @NotNull(message = "영업 시작시간은 필수입니다")
     @JsonFormat(pattern = "HH:mm")
     private LocalTime openTime;
 
+    @Schema(description = "영업 종료 시간", example = "23:00")
     @NotNull(message = "영업 종료시간은 필수입니다")
     @JsonFormat(pattern = "HH:mm")
     private LocalTime closeTime;
 
+    @Schema(description = "가게상태")
     private StoreStatus status;
-//    private Boolean isHidden;
-//    private Boolean isDeleted;
 }

--- a/src/main/java/com/example/whostolemyfood/store/presentation/dto/request/StoreSearchConditionV1.java
+++ b/src/main/java/com/example/whostolemyfood/store/presentation/dto/request/StoreSearchConditionV1.java
@@ -1,5 +1,6 @@
 package com.example.whostolemyfood.store.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -8,17 +9,24 @@ import java.util.UUID;
 
 @Getter
 @Setter // 컨트롤러에서 파라미터 바인딩을 위해 필요할 수 있음
+@Schema(description = "조건별 조회 조건 객체")
 @NoArgsConstructor
 public class StoreSearchConditionV1 {
 
+    @Schema(description = "가게명 또는 키워드", example = "치킨")
     private String keyword;    // 가게명 또는 메뉴명 키워드
+    @Schema(description = "카테고리", example = "")
     private UUID categoryId;   // 카테고리 UUID
+    @Schema(description = "지역명", example = "종로")
     private String region;     // 지역명
 
     // Integer로 변경하여 null 체크가 가능하도록 함
+    @Schema(description = "최소 주문 금액", example = "20000")
     private Integer minOrderPrice;
 
+    @Schema(description = "정렬 기준", example = "createdAt")
     private String sortBy;     // 정렬 기준 (예: "createdAt", "rating")
+
 
     private Integer page = 0;
     private Integer size = 10;

--- a/src/main/java/com/example/whostolemyfood/user/presentation/controller/UserAdminControllerV1.java
+++ b/src/main/java/com/example/whostolemyfood/user/presentation/controller/UserAdminControllerV1.java
@@ -1,6 +1,10 @@
 package com.example.whostolemyfood.user.presentation.controller;
 
 import java.util.UUID;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
 import org.springframework.data.domain.Page;
@@ -22,6 +26,7 @@ import com.example.whostolemyfood.user.application.security.AuthUser;
 
 import lombok.RequiredArgsConstructor;
 
+@Tag(name = "UserAdmin API", description = "관리자 유저 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin/users")
@@ -30,6 +35,7 @@ public class UserAdminControllerV1 {
     private final UserAdminServiceV1 userAdminService;
 
     //1. 전체 사용자 목록 조회 (본인 제외)
+    @Operation(summary = "사용자 전체 조회(본인 제외)", description = "[MANAGER / MASTER] 관리자가 전체 사용자 목록을 조회합니다.")
     @GetMapping
     @PreAuthorize("hasAnyRole('MASTER', 'MANAGER')")
     public ResponseEntity<PageResponse<ResGetUserByIdDtoV1>> getAllUsers(
@@ -44,6 +50,7 @@ public class UserAdminControllerV1 {
     }
 
     // 2. 특정 사용자 상세 정보 조회
+    @Operation(summary = "특정 사용자 조회", description =  "[MANAGER / MASTER] 관리자가 특정 사용자를 조회합니다.")
     @GetMapping("/{userId}")
     @PreAuthorize("hasAnyRole('MASTER', 'MANAGER')")
     public ResponseEntity<ResGetUserByIdDtoV1> getUserDetail(@PathVariable UUID userId) {
@@ -68,6 +75,7 @@ public class UserAdminControllerV1 {
 //    }
 
     // 4. [MASTER 전용] 매니저 생성
+    @Operation(summary = "매니저 임명", description = "[MASTER] 관리자가 매니저를 임명합니다.")
     @PostMapping("/managers")
     @PreAuthorize("hasRole('MASTER')")
     public ResponseEntity<ResGetUserByIdDtoV1> createManager(
@@ -77,6 +85,7 @@ public class UserAdminControllerV1 {
     }
 
     // 5. [MASTER 전용] 매니저 삭제
+    @Operation(summary = "매니저 권한 삭제", description = "[MASTER] 관리자가 매니저의 권한을 삭제합니다.")
     @DeleteMapping("/managers/{userId}")
     @PreAuthorize("hasRole('MASTER')")
     public ResponseEntity<Void> deleteManager(

--- a/src/main/java/com/example/whostolemyfood/user/presentation/controller/UserControllerV1.java
+++ b/src/main/java/com/example/whostolemyfood/user/presentation/controller/UserControllerV1.java
@@ -1,5 +1,7 @@
 package com.example.whostolemyfood.user.presentation.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
@@ -13,6 +15,7 @@ import com.example.whostolemyfood.user.presentation.dto.response.ResUpdateUserDt
 
 import lombok.RequiredArgsConstructor;
 
+@Tag(name = "User API",description = "유저 관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/user")
@@ -21,6 +24,7 @@ public class UserControllerV1 {
     private final UserService userService;
 
     // 내 정보 조회
+    @Operation(summary = "내 정보 조회", description = "유저가 자신의 정보를 조회합니다.")
     @GetMapping("/me")
     public ResponseEntity<ResGetUserByIdDtoV1> getMyInfo(
             @AuthenticationPrincipal AuthUser loginUser // 1. 타입 변경!
@@ -30,7 +34,7 @@ public class UserControllerV1 {
     }
 
     //
-
+    @Operation(summary = "내 정보 수정", description = "유저가 자신의 정보를 수정합니다.")
     @PatchMapping("/me")
     public ResponseEntity<ResUpdateUserDtoV1> updateMyInfo(
             @AuthenticationPrincipal AuthUser loginUser,

--- a/src/main/java/com/example/whostolemyfood/user/presentation/dto/request/ReqGetUserByIdDtoV1.java
+++ b/src/main/java/com/example/whostolemyfood/user/presentation/dto/request/ReqGetUserByIdDtoV1.java
@@ -6,6 +6,7 @@ import com.example.whostolemyfood.user.domain.entity.UserEntity;
 import com.example.whostolemyfood.user.domain.entity.UserRole;
 import com.example.whostolemyfood.user.domain.entity.UserStatus;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,13 +14,18 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@Schema(description = "유저 조회 요청 객체")
 @NoArgsConstructor
 @AllArgsConstructor
 public class ReqGetUserByIdDtoV1 {
 
+    @Schema(description = "유저아이디")
     private UUID userId;
+    @Schema(description = "유저 이메일", example = "test@email.com")
     private String email;
+    @Schema(description = "유저 비밀번호", example = "1234Asdf!")
     private String userName;
+    @Schema(description = "유저 권한", example = "OWNER")
     private UserRole role;
 //    private UserStatus status; // 새로 추가한 상태값도 응답에 포함!
 

--- a/src/main/java/com/example/whostolemyfood/user/presentation/dto/request/ReqUpdateUserDtoV1.java
+++ b/src/main/java/com/example/whostolemyfood/user/presentation/dto/request/ReqUpdateUserDtoV1.java
@@ -1,9 +1,11 @@
 package com.example.whostolemyfood.user.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Schema(description = "유저 수정 요청 객체")
 @NoArgsConstructor
 public class ReqUpdateUserDtoV1 {
     private String name;


### PR DESCRIPTION
<br/>

## ✨  제목 : Swagger 설정 및 API 문서화 menuService 리펙토링


<br/>

## 🔨 작업 내용

- swagger 문서화를 위한 config 설정 및 controller / dto 리펙토링
- menuSerive 검즘 로직 리펙토링


  
<br/>

## 🍻  실행된 화면(postman에서 테스트한 것 캡쳐해서 올려주세요 성공, 예외처리되는것까지)

-  swagger authorize 적용 부분
<img width="1296" height="227" alt="스크린샷 2026-04-28 오후 5 36 02" src="https://github.com/user-attachments/assets/c32ea682-4803-4141-8621-040756876e81" />

- 페이징 사용하는 모든 url은 해당 sort에 정렬 방식을 적어야 합니다
<img width="637" height="854" alt="스크린샷 2026-04-28 오후 5 36 47" src="https://github.com/user-attachments/assets/61b9ef54-1575-4d17-b0bf-58561cebd87a" />

<img width="618" height="853" alt="스크린샷 2026-04-28 오후 5 37 29" src="https://github.com/user-attachments/assets/d715185d-29b5-46c8-8a9d-d09c05d25037" />


<br/>

## 🔎   앞으로의 과제
