### PR TITLE
Refactor/#91  Search category, area left join 적용

### DIFF
--- a/src/main/java/com/example/whostolemyfood/store/infrastructure/repository/StoreRepositoryCustomImpl.java
+++ b/src/main/java/com/example/whostolemyfood/store/infrastructure/repository/StoreRepositoryCustomImpl.java
@@ -76,8 +76,8 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
                         storeRating.averageRating //평균 평점
                 ))
                 .from(store)
-                .join(store.category, category)
-                .join(store.area, area)
+                .leftJoin(store.category, category)
+                .leftJoin(store.area, area)
                 .join(store.storeRatingSummary, storeRating)
                 .leftJoin(menu).on(menu.store.eq(store),menu.isDeleted.isFalse(),menu.isHidden.isFalse())
                 .where(
@@ -99,8 +99,8 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
         Long total = queryFactory
                 .select(store.countDistinct())
                 .from(store)
-                .join(store.category, category)
-                .join(store.area, area)
+                .leftJoin(store.category, category)
+                .leftJoin(store.area, area)
                 .join(store.storeRatingSummary, storeRating)
                 .leftJoin(menu).on(menu.store.eq(store),menu.isDeleted.isFalse(),menu.isHidden.isFalse())
                 .where(

--- a/src/test/java/com/example/whostolemyfood/store/StoreRepositoryCustomImplTest.java
+++ b/src/test/java/com/example/whostolemyfood/store/StoreRepositoryCustomImplTest.java
@@ -7,6 +7,7 @@ import com.example.whostolemyfood.global.config.JpaAuditingConfig;
 import com.example.whostolemyfood.global.config.search.QueryDSLConfig;
 import com.example.whostolemyfood.menu.domain.entity.MenuEntity;
 import com.example.whostolemyfood.store.domain.entity.StoreEntity;
+import com.example.whostolemyfood.store.domain.entity.StoreRatingSummaryEntity;
 import com.example.whostolemyfood.store.domain.repository.StoreRepositoryCustom;
 import com.example.whostolemyfood.store.infrastructure.repository.StoreRepositoryCustomImpl;
 import com.example.whostolemyfood.store.presentation.dto.request.StoreSearchConditionV1;
@@ -24,6 +25,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.time.LocalTime;
 import java.util.UUID;
 
@@ -66,11 +68,20 @@ class StoreRepositoryCustomImplTest {
                 .isDefault(false)
                 .build();
 
+        StoreRatingSummaryEntity ratingSummary = StoreRatingSummaryEntity.builder()
+                .averageRating(BigDecimal.ZERO)
+                .reviewCount(0)
+                .totalRatingSum(0)
+                .build();
+        em.persist(ratingSummary);
+
+
         StoreEntity store = StoreEntity.builder()
                 .name("짜장백개")
                 .address("대구 중구 종로 100")
                 .phone("053-123-4567")
                 .content("정통 중식 전문점")
+                .storeRatingSummary(ratingSummary)
                 .category(category)
                 .area(area)
                 .openTime(LocalTime.of(11, 0))


### PR DESCRIPTION
- null이여도 검색 가능

<br/>

##   refactor/#91  Search category, area left join 적용


<br/>

## 이슈 발생

- search 시에 store table과 category, area join -> 이 값이 null 이면 검색 X


## 🔨 작업 내용

- store table과 category, area를 left join 함 -> 이 값들이 null이여도 검색 가능



  
<br/>

## 🍻  실행된 화면(postman에서 테스트한 것 캡쳐해서 올려주세요 성공, 예외처리되는것까지)

- '귤귤규류규률귤' && 'BBQ 스파르타점' category, area null
<img width="601" height="851" alt="스크린샷 2026-04-29 오후 12 30 35" src="https://github.com/user-attachments/assets/33be5d2f-5eb5-470e-bbb5-856e6fbd2eaf" />


<br/>

## 🔎   앞으로의 과제

- readme 작성


  <br/>

