### PR TITLE
[Fix] payment 통합 테스트 오류 수정 

### DIFF
--- a/src/main/java/com/example/whostolemyfood/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/whostolemyfood/global/exception/ErrorCode.java
@@ -61,6 +61,7 @@ public enum ErrorCode {
     PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "결제를 찾을 수 없습니다."),
     FAIL_TO_MODIFY_STATUS(HttpStatus.BAD_REQUEST, "P002", "결제 상태를 변경할 수 없습니다."),
     FAIL_PAY(HttpStatus.BAD_REQUEST, "P003", "결제가 거절되었습니다."),
+    DIFFERENT_PRICE(HttpStatus.BAD_REQUEST, "P004", "주문과 결제 금액이 다릅니다."),
 
     // Category
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND,"C001","존재하지 않는 카테고리입니다."),

--- a/src/main/java/com/example/whostolemyfood/payment/application/service/PaymentServiceV1.java
+++ b/src/main/java/com/example/whostolemyfood/payment/application/service/PaymentServiceV1.java
@@ -34,8 +34,8 @@ public class PaymentServiceV1 {
     public PageRes getPayments(Pageable pageable) {
 
         UUID currentAuditor = getCurrentAuditor();
-        if(pageable.getPageSize()>50){
-            pageable = PageRequest.of(pageable.getPageNumber(), 50, pageable.getSort());
+        if(pageable.getPageSize()!=10&&pageable.getPageSize()!=30&&pageable.getPageSize()!=50){
+            pageable = PageRequest.of(pageable.getPageNumber(), 10, pageable.getSort());
         }
         Page<PaymentEntity> allByCreatedBy = paymentRepository.findAllByCreatedBy(currentAuditor, pageable);
         Page<ResPayList> map = allByCreatedBy.map(ResPayList::new);
@@ -56,6 +56,9 @@ public class PaymentServiceV1 {
 
         UUID currentAuditor = getCurrentAuditor();
         OrderEntity orderEntity = orderRepository.findByOrderIdAndUserId(UUID.fromString(reqMakePay.getOrderId()), currentAuditor).orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+        if (orderEntity.getTotalPrice().longValue()!=reqMakePay.getAmount()){
+            throw new CustomException(ErrorCode.DIFFERENT_PRICE);
+        }
         PaymentEntity paymentEntity = new PaymentEntity(reqMakePay, orderEntity, currentAuditor);
         paymentRepository.save(paymentEntity);
         return new ResMakePay(paymentEntity.getId(), paymentEntity.getPaymentKey());


### PR DESCRIPTION
<br/>

## ✨  제목 : [Fix] payment 통합 테스트 오류 수정 


<br/>

## 🔨 작업 내용

- 페이징 10,30,50 범위 밖의 size는 10으로 크기 고정

- pay와 order의 결제 금액 비교


  
<br/>

## 🍻  실행된 화면(postman에서 테스트한 것 캡쳐해서 올려주세요 성공, 예외처리되는것까지)

- 페이징 크기 고정
<img width="505" height="518" alt="image" src="https://github.com/user-attachments/assets/9c758ce4-65cd-402b-bad2-57a6cfc5700d" />

- 결제, 주문 금액 비교
<img width="500" height="443" alt="image" src="https://github.com/user-attachments/assets/3ee2c6f5-b1c2-4afa-b85c-55475df2185a" />

<img width="503" height="424" alt="image" src="https://github.com/user-attachments/assets/31fa1d2b-681c-48a9-ab4f-f488091b13e3" />

<br/>

## 🔎   앞으로의 과제

- 추가로 발견되는 예외 존재시 수정
